### PR TITLE
feat: add dashboard layout with sidebar navigation

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -15,11 +15,11 @@ import TasksPanel from './components/TasksPanel.jsx';
 import Presence from './components/Presence.jsx';
 import Customer360 from './components/Customer360.jsx';
 
-import { Grid, Column } from '@twilio-paste/core/grid';
 import { Box } from '@twilio-paste/core/box';
 import { Heading } from '@twilio-paste/core/heading';
 import { Button } from '@twilio-paste/core/button';
 import { Toaster } from '@twilio-paste/core/toast';
+import DashboardLayout from './components/DashboardLayout.jsx';
 
 function AgentApp() {
   const { worker, activity, reservations, setAvailable } = useWorker();
@@ -42,20 +42,25 @@ function AgentApp() {
 
       <StatusBar label={activity || '…'} onChange={(sid) => setAvailable(sid)} />
 
-      <Grid gutter={['space30', 'space60']} marginTop="space70">
-        <Column span={[12, 12, 6]}>
-          <Softphone />
-          <Box height="space60" />
-          <Presence />
-        </Column>
-        <Column span={[12, 12, 6]}>
-          <Customer360 />
-          <Box height="space60" />
-          <TasksPanel setAvailable={setAvailable} />
-          <Box height="space60" />
-          <Reservations items={reservations} />
-        </Column>
-      </Grid>
+      <Box marginTop="space70">
+        <DashboardLayout
+          sections={[
+            { id: 'softphone', label: 'Softphone', content: <Softphone /> },
+            { id: 'customer360', label: 'Customer360', content: <Customer360 /> },
+            {
+              id: 'tasks',
+              label: 'Tasks',
+              content: <TasksPanel setAvailable={setAvailable} />,
+            },
+            { id: 'presence', label: 'Presence', content: <Presence /> },
+            {
+              id: 'reservations',
+              label: 'Reservations',
+              content: <Reservations items={reservations} />,
+            },
+          ]}
+        />
+      </Box>
     </Box>
   );
 }

--- a/client/src/components/DashboardLayout.jsx
+++ b/client/src/components/DashboardLayout.jsx
@@ -1,0 +1,45 @@
+import { useState } from 'react';
+import { Box } from '@twilio-paste/core/box';
+import {
+  Sidebar,
+  SidebarHeader,
+  SidebarHeaderLabel,
+  SidebarBody,
+  SidebarNavigation,
+  SidebarNavigationItem,
+} from '@twilio-paste/core/sidebar';
+
+export default function DashboardLayout({ sections }) {
+  const [active, setActive] = useState(sections[0]?.id);
+
+  return (
+    <Box display="flex" flexDirection={["column", "column", "row"]} minHeight="size100vh">
+      <Sidebar variant="default">
+        <SidebarHeader>
+          <SidebarHeaderLabel>Menu</SidebarHeaderLabel>
+        </SidebarHeader>
+        <SidebarBody>
+          <SidebarNavigation aria-label="Primary navigation">
+            {sections.map((section) => (
+              <SidebarNavigationItem
+                key={section.id}
+                href="#"
+                selected={active === section.id}
+                onClick={() => setActive(section.id)}
+              >
+                {section.label}
+              </SidebarNavigationItem>
+            ))}
+          </SidebarNavigation>
+        </SidebarBody>
+      </Sidebar>
+      <Box flex="1" padding="space60">
+        {sections.map((section) => (
+          <Box key={section.id} display={active === section.id ? 'block' : 'none'}>
+            {section.content}
+          </Box>
+        ))}
+      </Box>
+    </Box>
+  );
+}


### PR DESCRIPTION
## Summary
- add DashboardLayout component using Twilio Paste Sidebar
- wrap AgentApp in sidebar layout with sections for Softphone, Customer360, Tasks, Presence, and Reservations

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a638fe88a8832a9c5f4cedad515c6e