### PR TITLE
feat: add filtering and sorting to presence

### DIFF
--- a/client/src/i18n.js
+++ b/client/src/i18n.js
@@ -165,6 +165,10 @@ const resources = {
       "no": "No",
       "contactUri": "Contact URI",
       "presenceLoadError": "Failed to load presence.",
+      "filterAgentsPlaceholder": "Filter by name or activity",
+      "filterAgentsAria": "Filter agents",
+      "sortByActivity": "Sort by activity",
+      "sortByAvailability": "Sort by availability",
 
       // App
       "agentDesktop": "Agent Desktop",
@@ -334,6 +338,10 @@ const resources = {
       "no": "No",
       "contactUri": "URI de Contacto",
       "presenceLoadError": "No se pudo cargar la presencia.",
+      "filterAgentsPlaceholder": "Filtrar por nombre o actividad",
+      "filterAgentsAria": "Filtrar agentes",
+      "sortByActivity": "Ordenar por actividad",
+      "sortByAvailability": "Ordenar por disponibilidad",
       "transferTo": "Transferir a",
       "whisperTo": "Susurrar a",
 


### PR DESCRIPTION
## Summary
- add input to filter presence by name or activity
- enable client-side sorting by activity and availability
- extend i18n strings for new filter and sort controls

## Testing
- `npm test --prefix client` *(fails: Missing script)*
- `npm run build --prefix client`


------
https://chatgpt.com/codex/tasks/task_e_68a660f6d9ac832aad804574d3a43174