### PR TITLE
feat: add toast notifications and status indicators

### DIFF
--- a/client/src/i18n.js
+++ b/client/src/i18n.js
@@ -43,6 +43,7 @@ const resources = {
       "schedule": "Schedule",
       "scheduleMissingFields": "Missing fields for scheduling.",
       "scheduleError": "Failed to schedule appointment.",
+      "scheduleSuccess": "Appointment scheduled.",
       "crmFetchError": "Failed to fetch CRM data.",
 
       // Softphone
@@ -216,6 +217,7 @@ const resources = {
       "schedule": "Programar",
       "scheduleMissingFields": "Faltan campos para programar.",
       "scheduleError": "No se pudo programar la cita.",
+      "scheduleSuccess": "Cita programada.",
       "crmFetchError": "No se pudieron obtener datos de CRM.",
 
       // Softphone


### PR DESCRIPTION
## Summary
- surface schedule and paylink actions with inline status feedback
- use Paste Toasts for action confirmations
- expose error alerts via aria-live region

## Testing
- `npm test --prefix client` *(fails: Missing script "test")*
- `npm run build --prefix client`

------
https://chatgpt.com/codex/tasks/task_e_68a66268b068832aab1bf8d00921a7ed