### PR TITLE
feat: add validation and loading state to login

### DIFF
--- a/client/src/components/Login.jsx
+++ b/client/src/components/Login.jsx
@@ -10,21 +10,38 @@ import { Button } from '@twilio-paste/core/button';
 import { Stack } from '@twilio-paste/core/stack';
 import { Card } from '@twilio-paste/core/card';
 import { Callout, CalloutHeading, CalloutText } from '@twilio-paste/core/callout';
+import { FormControl } from '@twilio-paste/core/form';
+import { HelpText } from '@twilio-paste/core/help-text';
+import { Spinner } from '@twilio-paste/core/spinner';
 export default function Login({ onReady }) {
-  const [agentId, setAgentId] = useState('42');
-  const [workerSid, setWorkerSid] = useState('WK7e59fecd3f4064d7b1bd8cb9e7e7c49c');
-  const [identity, setIdentity] = useState('client:agent:42');
+  const [agentId, setAgentId] = useState('');
+  const [workerSid, setWorkerSid] = useState('');
+  const [identity, setIdentity] = useState('');
   const [error, setError] = useState('');
+  const [fieldErrors, setFieldErrors] = useState({});
+  const [loading, setLoading] = useState(false);
 
   async function submit(e) {
     e.preventDefault();
     setError('');
+    const errors = {};
+    if (!agentId) errors.agentId = 'Agent ID is required';
+    if (!workerSid) errors.workerSid = 'Worker SID is required';
+    if (!identity) errors.identity = 'Identity is required';
+    if (Object.keys(errors).length) {
+      setFieldErrors(errors);
+      return;
+    }
+    setFieldErrors({});
+    setLoading(true);
     try {
       const data = await Api.login(agentId, workerSid, identity);
       setAuth(data.token);
       onReady({ agent: data.agent });
     } catch (err) {
       setError(err?.response?.data?.error || 'Login failed');
+    } finally {
+      setLoading(false);
     }
   }
 
@@ -41,19 +58,69 @@ export default function Login({ onReady }) {
         <Heading as="h3" variant="heading30" marginBottom="space70">Sign in</Heading>
         <Box as="form" onSubmit={submit}>
           <Stack orientation="vertical" spacing="space70">
-            <Box>
+            <FormControl>
               <Label htmlFor="agentId">Agent ID</Label>
-              <Input id="agentId" value={agentId} onChange={e => setAgentId(e.target.value)} />
-            </Box>
-            <Box>
+              <Input
+                id="agentId"
+                value={agentId}
+                onChange={e => {
+                  setAgentId(e.target.value);
+                  if (fieldErrors.agentId)
+                    setFieldErrors(prev => ({ ...prev, agentId: undefined }));
+                }}
+                required
+                autoFocus
+                hasError={Boolean(fieldErrors.agentId)}
+              />
+              {fieldErrors.agentId ? (
+                <HelpText variant="error">{fieldErrors.agentId}</HelpText>
+              ) : null}
+            </FormControl>
+            <FormControl>
               <Label htmlFor="workerSid">Worker SID</Label>
-              <Input id="workerSid" value={workerSid} onChange={e => setWorkerSid(e.target.value)} />
-            </Box>
-            <Box>
+              <Input
+                id="workerSid"
+                value={workerSid}
+                onChange={e => {
+                  setWorkerSid(e.target.value);
+                  if (fieldErrors.workerSid)
+                    setFieldErrors(prev => ({ ...prev, workerSid: undefined }));
+                }}
+                required
+                hasError={Boolean(fieldErrors.workerSid)}
+              />
+              {fieldErrors.workerSid ? (
+                <HelpText variant="error">{fieldErrors.workerSid}</HelpText>
+              ) : null}
+            </FormControl>
+            <FormControl>
               <Label htmlFor="identity">Identity (client:agent:42)</Label>
-              <Input id="identity" value={identity} onChange={e => setIdentity(e.target.value)} />
-            </Box>
-            <Button variant="primary" type="submit">Login</Button>
+              <Input
+                id="identity"
+                value={identity}
+                onChange={e => {
+                  setIdentity(e.target.value);
+                  if (fieldErrors.identity)
+                    setFieldErrors(prev => ({ ...prev, identity: undefined }));
+                }}
+                required
+                hasError={Boolean(fieldErrors.identity)}
+              />
+              {fieldErrors.identity ? (
+                <HelpText variant="error">{fieldErrors.identity}</HelpText>
+              ) : null}
+            </FormControl>
+            <Button variant="primary" type="submit" disabled={loading}>
+              {loading ? (
+                <>
+                  <Spinner decorative={false} title="Loading" size="sizeIcon20" />
+                  {' '}
+                  Logging in...
+                </>
+              ) : (
+                'Login'
+              )}
+            </Button>
           </Stack>
         </Box>
       </Card>


### PR DESCRIPTION
## Summary
- add field validation and inline error messages to login form
- autofocus first login field and show spinner while submitting

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a662702c08832a96417c68326d99ba