### PR TITLE
Handle wildcard CORS origin

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -25,8 +25,15 @@ const corsOrigins = (env.corsOrigin || '')
   .map(s => s.trim())
   .filter(Boolean);
 
+const origin =
+  env.corsOrigin === '*'
+    ? true
+    : corsOrigins.length
+      ? corsOrigins
+      : false; // false = bloquea si no hay match
+
 const corsOptions = {
-  origin: corsOrigins.length ? corsOrigins : false, // false = bloquea si no hay match
+  origin,
   methods: ['GET', 'HEAD', 'PUT', 'PATCH', 'POST', 'DELETE', 'OPTIONS'],
   allowedHeaders: ['Content-Type', 'Authorization'],
   exposedHeaders: ['Content-Type', 'Authorization'],
@@ -54,7 +61,7 @@ app.use('/api', crmProxy);
 const server = http.createServer(app);
 const io = new Server(server, {
   cors: {
-    origin: corsOrigins.length ? corsOrigins : false,
+    origin,
     methods: ['GET', 'POST'],
     credentials: true,
   },


### PR DESCRIPTION
## Summary
- support wildcard `*` for CORS origin configuration
- reuse shared origin settings for Socket.IO CORS

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68a667548e88832a9fe2de6781d63f88