### PR TITLE
Restrict JWT algorithm to HS256

### DIFF
--- a/server/src/auth.js
+++ b/server/src/auth.js
@@ -2,14 +2,18 @@ import jwt from 'jsonwebtoken';
 import { env } from './env.js';
 
 export function signAgentToken(sub, workerSid, identity) {
-  return jwt.sign({ sub, workerSid, identity }, env.jwtSecret, { expiresIn: '8h' });
+  return jwt.sign(
+    { sub, workerSid, identity },
+    env.jwtSecret,
+    { expiresIn: '8h', algorithm: 'HS256' }
+  );
 }
 
 export function requireAuth(req, res, next) {
   const raw = req.headers.authorization && req.headers.authorization.split(' ')[1];
   if (!raw) return res.status(401).json({ error: 'missing token' });
   try {
-    req.claims = jwt.verify(raw, env.jwtSecret);
+    req.claims = jwt.verify(raw, env.jwtSecret, { algorithms: ['HS256'] });
     next();
   } catch {
     res.status(401).json({ error: 'invalid token' });

--- a/server/test/auth.test.js
+++ b/server/test/auth.test.js
@@ -1,0 +1,38 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import jwt from 'jsonwebtoken';
+
+import { signAgentToken, requireAuth } from '../src/auth.js';
+import { env } from '../src/env.js';
+
+function createRes() {
+  const res = {};
+  res.status = (code) => { res.statusCode = code; return res; };
+  res.json = (body) => { res.body = body; return res; };
+  return res;
+}
+
+test('accepts tokens signed with HS256', () => {
+  const token = signAgentToken('user', 'WS123', 'alice');
+  const req = { headers: { authorization: `Bearer ${token}` } };
+  const res = createRes();
+  let called = false;
+
+  requireAuth(req, res, () => { called = true; });
+
+  assert.equal(called, true);
+  assert.equal(res.statusCode, undefined);
+});
+
+test('rejects tokens signed with non-HS256 algorithms', () => {
+  const token = jwt.sign({ sub: 'user' }, env.jwtSecret, { algorithm: 'HS512' });
+  const req = { headers: { authorization: `Bearer ${token}` } };
+  const res = createRes();
+  let called = false;
+
+  requireAuth(req, res, () => { called = true; });
+
+  assert.equal(called, false);
+  assert.equal(res.statusCode, 401);
+  assert.deepEqual(res.body, { error: 'invalid token' });
+});


### PR DESCRIPTION
## Summary
- specify HS256 when signing agent tokens
- verify tokens using HS256 only
- add tests rejecting tokens signed with other algorithms

## Testing
- `cd server && node --test`


------
https://chatgpt.com/codex/tasks/task_e_68a66757b4a4832a8271c87a646d892e