### PR TITLE
Set mute/unmute icons decorative

### DIFF
--- a/client/src/components/Softphone.jsx
+++ b/client/src/components/Softphone.jsx
@@ -234,11 +234,11 @@ export default function Softphone() {
             >
               {isMuted ? (
                 <>
-                  <MicrophoneOffIcon decorative={false} /> {t('unmute')}
+                  <MicrophoneOffIcon decorative /> {t('unmute')}
                 </>
               ) : (
                 <>
-                  <MicrophoneOnIcon decorative={false} /> {t('mute')}
+                  <MicrophoneOnIcon decorative /> {t('mute')}
                 </>
               )}
             </Button>


### PR DESCRIPTION
## Summary
- mark microphone icons in softphone as decorative since text labels provide context

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a66b3e8374832a9e1f97741b0130c1