### PR TITLE
Use flex layout for AgentApp

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -33,7 +33,7 @@ function AgentApp() {
   }
 
   return (
-    <Box>
+    <Box display="flex" flexDirection="column" minHeight="size100vh">
       <Toaster />
       <Button variant="destructive" onClick={logout}>Logout</Button>
       <Heading as="h2" variant="heading20" marginBottom="space60">
@@ -42,7 +42,7 @@ function AgentApp() {
 
       <StatusBar label={activity || '…'} onChange={(sid) => setAvailable(sid)} />
 
-      <Box marginTop="space70">
+      <Box marginTop="space70" flex="1" overflowY="auto">
         <DashboardLayout
           sections={[
             { id: 'softphone', label: 'Softphone', content: <Softphone /> },


### PR DESCRIPTION
## Summary
- make AgentApp root a flex column taking full height
- allow DashboardLayout to flex and scroll independently of header controls

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a66f0d7538832a88b1fc059f4a688c