### PR TITLE
feat: add mobile sidebar disclosure toggle

### DIFF
--- a/client/src/components/DashboardLayout.jsx
+++ b/client/src/components/DashboardLayout.jsx
@@ -8,9 +8,47 @@ import {
   SidebarNavigation,
   SidebarNavigationItem,
 } from '@twilio-paste/core/sidebar';
+import {
+  Disclosure,
+  DisclosureContent,
+  DisclosureHeading,
+  useDisclosureState,
+} from '@twilio-paste/core/disclosure';
+import { Button } from '@twilio-paste/core/button';
+import { MenuIcon } from '@twilio-paste/icons/esm/MenuIcon';
 
 export default function DashboardLayout({ sections }) {
   const [active, setActive] = useState(sections[0]?.id);
+  const disclosure = useDisclosureState();
+
+  const handleSelect = (id) => {
+    setActive(id);
+    if (disclosure.visible) {
+      disclosure.hide();
+    }
+  };
+
+  const sidebarNav = (
+    <>
+      <SidebarHeader>
+        <SidebarHeaderLabel>Menu</SidebarHeaderLabel>
+      </SidebarHeader>
+      <SidebarBody>
+        <SidebarNavigation aria-label="Primary navigation">
+          {sections.map((section) => (
+            <SidebarNavigationItem
+              key={section.id}
+              href="#"
+              selected={active === section.id}
+              onClick={() => handleSelect(section.id)}
+            >
+              {section.label}
+            </SidebarNavigationItem>
+          ))}
+        </SidebarNavigation>
+      </SidebarBody>
+    </>
+  );
 
   return (
     <Box
@@ -18,25 +56,33 @@ export default function DashboardLayout({ sections }) {
       gridTemplateColumns={["1fr", "1fr", "240px 1fr"]}
       minHeight="size100vh"
     >
-      <Sidebar variant="default" gridColumn="1" flexShrink={0}>
-        <SidebarHeader>
-          <SidebarHeaderLabel>Menu</SidebarHeaderLabel>
-        </SidebarHeader>
-        <SidebarBody>
-          <SidebarNavigation aria-label="Primary navigation">
-            {sections.map((section) => (
-              <SidebarNavigationItem
-                key={section.id}
-                href="#"
-                selected={active === section.id}
-                onClick={() => setActive(section.id)}
-              >
-                {section.label}
-              </SidebarNavigationItem>
-            ))}
-          </SidebarNavigation>
-        </SidebarBody>
+      {/* Mobile Navigation */}
+      <Box display={["block", "block", "none"]} gridColumn="1">
+        <Disclosure state={disclosure}>
+          <DisclosureHeading
+            as={Button}
+            variant="secondary"
+            size="icon"
+            aria-label={disclosure.visible ? 'Hide navigation' : 'Show navigation'}
+          >
+            <MenuIcon decorative={false} title="Navigation menu" />
+          </DisclosureHeading>
+          <DisclosureContent>
+            <Sidebar variant="default">{sidebarNav}</Sidebar>
+          </DisclosureContent>
+        </Disclosure>
+      </Box>
+
+      {/* Desktop Sidebar */}
+      <Sidebar
+        variant="default"
+        gridColumn="1"
+        flexShrink={0}
+        display={["none", "none", "flex"]}
+      >
+        {sidebarNav}
       </Sidebar>
+
       <Box gridColumn={["1", "1", "2"]} overflow="auto">
         <Box padding="space60">
           {sections.map((section) => (


### PR DESCRIPTION
## Summary
- add Twilio Paste Disclosure and toggle button for mobile sidebar
- close navigation on selection and maintain desktop layout

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a6753a35e8832abcb33db373e1963b