### PR TITLE
feat: restructure dashboard layout with sidebar push wrapper

### DIFF
--- a/client/src/components/DashboardLayout.jsx
+++ b/client/src/components/DashboardLayout.jsx
@@ -7,18 +7,15 @@ import {
   SidebarBody,
   SidebarNavigation,
   SidebarNavigationItem,
+  SidebarPushContentWrapper,
 } from '@twilio-paste/core/sidebar';
 
 export default function DashboardLayout({ sections }) {
   const [active, setActive] = useState(sections[0]?.id);
 
   return (
-    <Box
-      display="grid"
-      gridTemplateColumns={["1fr", "1fr", "240px 1fr"]}
-      minHeight="size100vh"
-    >
-      <Sidebar variant="default" gridColumn="1" flexShrink={0}>
+    <Box display="flex" minHeight="size100vh">
+      <Sidebar variant="default" flexShrink={0}>
         <SidebarHeader>
           <SidebarHeaderLabel>Menu</SidebarHeaderLabel>
         </SidebarHeader>
@@ -37,7 +34,7 @@ export default function DashboardLayout({ sections }) {
           </SidebarNavigation>
         </SidebarBody>
       </Sidebar>
-      <Box gridColumn={["1", "1", "2"]} overflow="auto">
+      <SidebarPushContentWrapper overflow="auto">
         <Box padding="space60">
           {sections.map((section) => (
             <Box key={section.id} display={active === section.id ? 'block' : 'none'}>
@@ -45,7 +42,7 @@ export default function DashboardLayout({ sections }) {
             </Box>
           ))}
         </Box>
-      </Box>
+      </SidebarPushContentWrapper>
     </Box>
   );
 }


### PR DESCRIPTION
## Summary
- use SidebarPushContentWrapper alongside Sidebar in dashboard layout
- push main content so sidebar and sections display side-by-side

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a675b63704832a8f0690f4dc3f418f