### PR TITLE
feat: add mobile sidebar collapse

### DIFF
--- a/client/src/components/DashboardLayout.jsx
+++ b/client/src/components/DashboardLayout.jsx
@@ -7,19 +7,14 @@ import {
   SidebarBody,
   SidebarNavigation,
   SidebarNavigationItem,
+  SidebarCollapseButton,
+  SidebarPushContentWrapper,
 } from '@twilio-paste/core/sidebar';
-import {
-  Disclosure,
-  DisclosureContent,
-  DisclosureHeading,
-  useDisclosureState,
-} from '@twilio-paste/core/disclosure';
-import { Button } from '@twilio-paste/core/button';
-import { MenuIcon } from '@twilio-paste/icons/esm/MenuIcon';
+import { useDisclosureState as useDisclosure } from '@twilio-paste/core/disclosure';
 
 export default function DashboardLayout({ sections }) {
   const [active, setActive] = useState(sections[0]?.id);
-  const disclosure = useDisclosureState();
+  const disclosure = useDisclosure({ visible: true });
 
   const handleSelect = (id) => {
     setActive(id);
@@ -28,72 +23,42 @@ export default function DashboardLayout({ sections }) {
     }
   };
 
-  const sidebarNav = (
-    <>
-      <SidebarHeader>
-        <SidebarHeaderLabel>Menu</SidebarHeaderLabel>
-      </SidebarHeader>
-      <SidebarBody>
-        <SidebarNavigation aria-label="Primary navigation">
-          {sections.map((section) => (
-            <SidebarNavigationItem
-              key={section.id}
-              href="#"
-              selected={active === section.id}
-              onClick={() => handleSelect(section.id)}
-            >
-              {section.label}
-            </SidebarNavigationItem>
-          ))}
-        </SidebarNavigation>
-      </SidebarBody>
-    </>
-  );
-
   return (
-    <Box
+    <SidebarPushContentWrapper
+      collapsed={!disclosure.visible}
       display="flex"
-      flexDirection={["column", "column", "row"]}
       minHeight="size100vh"
     >
-      {/* Mobile Navigation */}
-      <Box display={["block", "block", "none"]}>
-        <Disclosure state={disclosure}>
-          <DisclosureHeading
-            as={Button}
-            variant="secondary"
-            size="icon"
-            aria-label={disclosure.visible ? 'Hide navigation' : 'Show navigation'}
-          >
-            <MenuIcon decorative={false} title="Navigation menu" />
-          </DisclosureHeading>
-          <DisclosureContent
-            position="absolute"
-            top="0"
-            left="0"
-            width="100%"
-            height="100vh"
-            backgroundColor="colorBackgroundBody"
-            zIndex="zIndex60"
-          >
-            <Sidebar variant="default" height="100%">
-              {sidebarNav}
-            </Sidebar>
-          </DisclosureContent>
-        </Disclosure>
-      </Box>
-
-      {/* Desktop Sidebar */}
       <Sidebar
         variant="default"
-        display={["none", "none", "flex"]}
         width="240px"
         flexShrink={0}
-        position="sticky"
-        top="0"
         height="100vh"
+        collapsed={!disclosure.visible}
       >
-        {sidebarNav}
+        <SidebarHeader>
+          <SidebarHeaderLabel>Menu</SidebarHeaderLabel>
+          <SidebarCollapseButton
+            display={["flex", "flex", "none"]}
+            i18nCollapseLabel="Hide navigation"
+            i18nExpandLabel="Show navigation"
+            onClick={disclosure.toggle}
+          />
+        </SidebarHeader>
+        <SidebarBody>
+          <SidebarNavigation aria-label="Primary navigation">
+            {sections.map((section) => (
+              <SidebarNavigationItem
+                key={section.id}
+                href="#"
+                selected={active === section.id}
+                onClick={() => handleSelect(section.id)}
+              >
+                {section.label}
+              </SidebarNavigationItem>
+            ))}
+          </SidebarNavigation>
+        </SidebarBody>
       </Sidebar>
 
       <Box as="main" flexGrow={1} overflow="auto" padding="space60">
@@ -103,6 +68,6 @@ export default function DashboardLayout({ sections }) {
           </Box>
         ))}
       </Box>
-    </Box>
+    </SidebarPushContentWrapper>
   );
 }


### PR DESCRIPTION
## Summary
- replace mobile navigation with collapsible sidebar
- wrap content with SidebarPushContentWrapper so layout adjusts when collapsed

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a67d89b384832a92bf4e6979fd756a