### PR TITLE
feat: improve responsive dashboard layout

### DIFF
--- a/client/src/components/DashboardLayout.jsx
+++ b/client/src/components/DashboardLayout.jsx
@@ -27,13 +27,16 @@ export default function DashboardLayout({ sections }) {
     <SidebarPushContentWrapper
       collapsed={!disclosure.visible}
       display="flex"
-      minHeight="size100vh"
+      flexDirection={["column", "row"]}
+      maxHeight="100vh"
+      overflowY="auto"
     >
       <Sidebar
         variant="default"
-        width="240px"
+        width={["100%", "240px"]}
         flexShrink={0}
-        height="100vh"
+        maxHeight="100vh"
+        overflowY="auto"
         collapsed={!disclosure.visible}
       >
         <SidebarHeader>


### PR DESCRIPTION
## Summary
- make sidebar responsive and stack vertically on small screens
- avoid 100vh height to prevent overflow on mobile devices

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a681b2ba38832a9d1b2efe2cf474fa