### PR TITLE
feat: make task actions responsive

### DIFF
--- a/client/src/components/TasksPanel.jsx
+++ b/client/src/components/TasksPanel.jsx
@@ -111,7 +111,7 @@ function TaskCard({ t, onFinishPress, onTransfer, onHold, onUnhold, onRecCtrl, h
         `}
       </style>
       <Stack orientation="vertical" spacing="space50">
-        <Stack orientation="horizontal" spacing="space40" alignment="center">
+        <Stack orientation={['vertical', 'horizontal']} spacing="space40" alignment="center" wrap>
           <Heading as="h4" variant="heading40" margin="space0">
             {t.sid}
           </Heading>
@@ -664,7 +664,7 @@ export default function TasksPanel({ onFinished, setAvailable }) {
           </Stack>
         </ModalBody>
         <ModalFooter>
-          <Stack orientation="horizontal" spacing="space40">
+          <Stack orientation={['vertical', 'horizontal']} spacing="space40" wrap>
             <Button aria-label={translate('cancelAria')} variant="secondary" onClick={() => setOpenTransfer(false)}>{translate('cancel')}</Button>
             <Button aria-label={translate('warmTransferAria')} variant="secondary" onClick={doWarm} disabled={!target && !externalNumber}>{translate('warmTransfer')}</Button>
             <Button aria-label={translate('coldTransferAria')} variant="primary" onClick={doCold} disabled={!target && !externalNumber}>{translate('coldTransfer')}</Button>
@@ -700,7 +700,7 @@ export default function TasksPanel({ onFinished, setAvailable }) {
           </Stack>
         </ModalBody>
         <ModalFooter>
-          <Stack orientation="horizontal" spacing="space40">
+          <Stack orientation={['vertical', 'horizontal']} spacing="space40" wrap>
             <Button aria-label={translate('cancelAria')} variant="secondary" onClick={() => setOpenWrap(false)}>{translate('cancel')}</Button>
             <Button aria-label={translate('completeAria')} variant="primary" onClick={doFinish}>{translate('complete')}</Button>
           </Stack>


### PR DESCRIPTION
## Summary
- make task card header stack responsive with wrap
- allow modal footer buttons to stack on small screens

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a681cc0c30832aaf16f3cf732773ab