### PR TITLE
fix: improve sidebar navigation accessibility

### DIFF
--- a/client/src/components/DashboardLayout.jsx
+++ b/client/src/components/DashboardLayout.jsx
@@ -50,7 +50,8 @@ export default function DashboardLayout({ sections }) {
             {sections.map((section) => (
               <SidebarNavigationItem
                 key={section.id}
-                href="#"
+                as="button"
+                aria-label={section.label}
                 selected={active === section.id}
                 onClick={() => handleSelect(section.id)}
               >


### PR DESCRIPTION
## Summary
- replace placeholder links with buttons in dashboard sidebar
- add aria labels for accessible navigation items

## Testing
- `npm test` (fails: Missing script: "test")
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_68a688e3dd80832ab445b3bec37a32bd