### PR TITLE
fix: remove invalid SidebarContainer import

### DIFF
--- a/client/src/components/DashboardLayout.jsx
+++ b/client/src/components/DashboardLayout.jsx
@@ -9,7 +9,6 @@ import {
   SidebarNavigation,
   SidebarNavigationItem,
   SidebarCollapseButton,
-  SidebarContainer,
   SidebarPushContentWrapper,
 } from '@twilio-paste/core/sidebar';
 import { useDisclosureState as useDisclosure } from '@twilio-paste/core/disclosure';
@@ -27,7 +26,7 @@ export default function DashboardLayout({ sections }) {
   };
 
   return (
-    <SidebarContainer maxHeight="100vh" overflowY="auto">
+    <Box display="flex" maxHeight="100vh" overflowY="auto">
       <Sidebar
         variant="default"
         width={["100%", "240px"]}
@@ -82,6 +81,6 @@ export default function DashboardLayout({ sections }) {
           ))}
         </Box>
       </SidebarPushContentWrapper>
-    </SidebarContainer>
+    </Box>
   );
 }


### PR DESCRIPTION
## Summary
- use Box flex container instead of unsupported SidebarContainer
- ensure Sidebar components import from @twilio-paste/core/sidebar

## Testing
- `npm install`
- `npm run dev`


------
https://chatgpt.com/codex/tasks/task_e_68a68b6810f4832aa80f23f1b4a1d712