### PR TITLE
feat: add reusable error boundary

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -21,6 +21,7 @@ import { Button } from '@twilio-paste/core/button';
 import { Toaster } from '@twilio-paste/core/toast';
 import { Stack } from '@twilio-paste/core/stack';
 import DashboardLayout from './components/DashboardLayout.jsx';
+import ErrorBoundary from './components/ErrorBoundary.jsx';
 
 function AgentApp() {
   const { worker, activity, reservations, setAvailable } = useWorker();
@@ -54,23 +55,25 @@ function AgentApp() {
       <StatusBar label={activity || '…'} onChange={(sid) => setAvailable(sid)} />
 
       <Box marginTop="space70" flex="1" overflowY="auto">
-        <DashboardLayout
-          sections={[
-            { id: 'softphone', label: 'Softphone', content: <Softphone /> },
-            { id: 'customer360', label: 'Customer360', content: <Customer360 /> },
-            {
-              id: 'tasks',
-              label: 'Tasks',
-              content: <TasksPanel setAvailable={setAvailable} />,
-            },
-            { id: 'presence', label: 'Presence', content: <Presence /> },
-            {
-              id: 'reservations',
-              label: 'Reservations',
-              content: <Reservations items={reservations} />,
-            },
-          ]}
-        />
+        <ErrorBoundary>
+          <DashboardLayout
+            sections={[
+              { id: 'softphone', label: 'Softphone', content: <Softphone /> },
+              { id: 'customer360', label: 'Customer360', content: <Customer360 /> },
+              {
+                id: 'tasks',
+                label: 'Tasks',
+                content: <TasksPanel setAvailable={setAvailable} />,
+              },
+              { id: 'presence', label: 'Presence', content: <Presence /> },
+              {
+                id: 'reservations',
+                label: 'Reservations',
+                content: <Reservations items={reservations} />,
+              },
+            ]}
+          />
+        </ErrorBoundary>
       </Box>
     </Box>
   );

--- a/client/src/components/ErrorBoundary.jsx
+++ b/client/src/components/ErrorBoundary.jsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { Box } from "@twilio-paste/core/box";
+import { Heading } from "@twilio-paste/core/heading";
+
+class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error, errorInfo) {
+    // Optional: Log errors for diagnostics
+    console.error("ErrorBoundary caught an error", error, errorInfo);
+    if (typeof this.props.onError === "function") {
+      this.props.onError(error, errorInfo);
+    }
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        this.props.fallback || (
+          <Box padding="space60">
+            <Heading as="h2" variant="heading20">
+              Something went wrong.
+            </Heading>
+          </Box>
+        )
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;


### PR DESCRIPTION
## Summary
- add reusable `ErrorBoundary` component
- wrap `DashboardLayout` with error boundary to catch render errors

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a68cf0d774832a9cf94e8d2016a407