### PR TITLE
Add PropTypes to DashboardLayout

### DIFF
--- a/client/src/components/DashboardLayout.jsx
+++ b/client/src/components/DashboardLayout.jsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import PropTypes from 'prop-types';
 import { Box } from '@twilio-paste/core/box';
 import { Button } from '@twilio-paste/core/button';
 import {
@@ -84,3 +85,17 @@ export default function DashboardLayout({ sections }) {
     </Box>
   );
 }
+
+DashboardLayout.propTypes = {
+  sections: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string.isRequired,
+      label: PropTypes.string.isRequired,
+      content: PropTypes.node.isRequired,
+    })
+  ).isRequired,
+};
+
+DashboardLayout.defaultProps = {
+  sections: [],
+};


### PR DESCRIPTION
## Summary
- define propTypes for DashboardLayout to validate section objects
- add default sections array

## Testing
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_68a68e000e30832ab7e5a85a746e6f03