### PR TITLE
refactor: centralize useLocalStorage hook

### DIFF
--- a/client/src/components/AgentDesktopShell.jsx
+++ b/client/src/components/AgentDesktopShell.jsx
@@ -1,5 +1,6 @@
 // contact-center/client/src/components/AgentDesktopShell.jsx
 import { useEffect, useMemo, useRef, useState, useCallback } from 'react';
+import useLocalStorage from '../hooks/useLocalStorage.js';
 import PropTypes from 'prop-types';
 
 import { Box } from '@twilio-paste/core/box';
@@ -83,7 +84,7 @@ export default function AgentDesktopShell({
 }) {
   const isDesktop = useIsDesktop();
   const [drawerOpen, setDrawerOpen] = useState(false);
-  const [activeId, setActiveId] = useState(sections?.[0]?.id || '');
+  const [activeId, setActiveId] = useLocalStorage('shell_active', sections?.[0]?.id || '');
   const [filter, setFilter] = useState('');
   const scrollRootRef = useRef(null);
   const navRefs = useRef({});
@@ -105,14 +106,12 @@ export default function AgentDesktopShell({
     return () => ro.disconnect();
   }, [measureTopFrom]);
 
-  // persistir sección activa
+  // ensure stored active section exists
   useEffect(() => {
-    if (activeId) localStorage.setItem('shell_active', activeId);
-  }, [activeId]);
-  useEffect(() => {
-    const saved = localStorage.getItem('shell_active');
-    if (saved && sections.some((s) => s.id === saved)) setActiveId(saved);
-  }, [sections]);
+    if (!sections.some((s) => s.id === activeId)) {
+      setActiveId(sections?.[0]?.id || '');
+    }
+  }, [sections, activeId, setActiveId]);
 
   // scrollspy para resaltar activo (cuando NO es modal)
   useEffect(() => {

--- a/client/src/components/Softphone.jsx
+++ b/client/src/components/Softphone.jsx
@@ -1,5 +1,6 @@
 // contact-center/client/src/components/Softphone.jsx
 import { useEffect, useMemo, useRef, useState, useCallback } from 'react';
+import useLocalStorage from '../hooks/useLocalStorage.js';
 import { VoiceDevice } from '../softphone/VoiceDevice.js';
 import { useTranslation } from 'react-i18next';
 
@@ -23,22 +24,6 @@ import {
 } from '@twilio-paste/core/modal';
 import { MicrophoneOnIcon } from '@twilio-paste/icons/esm/MicrophoneOnIcon';
 import { MicrophoneOffIcon } from '@twilio-paste/icons/esm/MicrophoneOffIcon';
-
-/* Persistencia simple */
-function useLocalStorage(key, initialValue) {
-  const [storedValue, setStoredValue] = useState(() => {
-    try { const item = window.localStorage.getItem(key); return item ? JSON.parse(item) : initialValue; }
-    catch { return initialValue; }
-  });
-  const setValue = (value) => {
-    try {
-      const next = value instanceof Function ? value(storedValue) : value;
-      setStoredValue(next);
-      window.localStorage.setItem(key, JSON.stringify(next));
-    } catch {}
-  };
-  return [storedValue, setValue];
-}
 
 /* =========================
  *        Softphone

--- a/client/src/components/TasksPanel.jsx
+++ b/client/src/components/TasksPanel.jsx
@@ -1,5 +1,6 @@
 // contact-center/client/src/components/TasksPanel.jsx
 import { useEffect, useMemo, useState } from 'react';
+import useLocalStorage from '../hooks/useLocalStorage.js';
 import { useQuery } from '@tanstack/react-query';
 import Api from '../api.js';
 import axios from 'axios';
@@ -315,9 +316,7 @@ export default function TasksPanel({ onFinished, setAvailable }) {
 
   const [availableSid, setAvailableSid] = useState('');
   const [breakSid, setBreakSid] = useState('');
-  const [afterFinishSid, setAfterFinishSid] = useState(
-    () => localStorage.getItem('after_finish_sid') || ''
-  );
+  const [afterFinishSid, setAfterFinishSid] = useLocalStorage('after_finish_sid', '');
 
   const [openTransfer, setOpenTransfer] = useState(false);
   const [transferTask, setTransferTask] = useState(null);
@@ -364,7 +363,6 @@ export default function TasksPanel({ onFinished, setAvailable }) {
       if (br) setBreakSid(br.sid);
       if (!afterFinishSid && avail) {
         setAfterFinishSid(avail.sid);
-        localStorage.setItem('after_finish_sid', avail.sid);
       }
     } catch (e) {
       console.error('activities error', e);
@@ -681,7 +679,6 @@ export default function TasksPanel({ onFinished, setAvailable }) {
                 value={afterFinishSid}
                 onChange={(e) => {
                   setAfterFinishSid(e.target.value);
-                  localStorage.setItem('after_finish_sid', e.target.value);
                 }}
               >
                 <Option value={availableSid || ''}>{translate('available')}</Option>

--- a/client/src/hooks/useLocalStorage.js
+++ b/client/src/hooks/useLocalStorage.js
@@ -1,0 +1,20 @@
+import { useState } from 'react';
+
+export default function useLocalStorage(key, initialValue) {
+  const [storedValue, setStoredValue] = useState(() => {
+    try {
+      const item = window.localStorage.getItem(key);
+      return item ? JSON.parse(item) : initialValue;
+    } catch {
+      return initialValue;
+    }
+  });
+  const setValue = (value) => {
+    try {
+      const next = value instanceof Function ? value(storedValue) : value;
+      setStoredValue(next);
+      window.localStorage.setItem(key, JSON.stringify(next));
+    } catch {}
+  };
+  return [storedValue, setValue];
+}


### PR DESCRIPTION
## Summary
- extract reusable `useLocalStorage` hook
- replace inline hook in `Softphone` with import
- persist settings in `AgentDesktopShell` and `TasksPanel` via shared hook

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a7301dd368832ab05ede73a91e7f0c