### PR TITLE
refactor: move useWorker hook to hooks directory

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -15,7 +15,7 @@ import Customer360 from './components/Customer360.jsx';
 import TasksPanel from './components/TasksPanel.jsx';
 import Reservations from './components/Reservations.jsx';
 
-import { useWorker } from './taskrouter/useWorker.js';
+import { useWorker } from './hooks/useWorker.js';
 import { Box } from '@twilio-paste/core/box';
 import { Stack } from '@twilio-paste/core/stack';
 import { Button } from '@twilio-paste/core/button';

--- a/client/src/hooks/useWorker.js
+++ b/client/src/hooks/useWorker.js
@@ -1,4 +1,4 @@
-// contact-center/client/src/taskrouter/useWorker.js
+// contact-center/client/src/hooks/useWorker.js
 import { useEffect, useRef, useState } from 'react';
 import Api from '../api.js';
 


### PR DESCRIPTION
## Summary
- create `src/hooks/` and move `useWorker` hook there
- update imports to consume `useWorker` from hooks directory

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a7302882d0832a845d51e6c08ffd23