### PR TITLE
chore: include packages folder in workspaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "twilio-contact-center",
   "private": true,
-  "workspaces": ["apps/*"],
+  "workspaces": ["apps/*", "packages/*"],
   "scripts": {
     "bootstrap": "npm install --workspaces"
   }


### PR DESCRIPTION
## Summary
- include packages workspace to support shared package imports

## Testing
- `npm install`
- `npm test` (fails: Missing script "test")
- `npm run dev -w apps/crm-orchestrator` (fails: Cannot find module 'shared/env')


------
https://chatgpt.com/codex/tasks/task_e_68a76c2bf944832a841af4f2768cab96