### PR TITLE
Fix shared env import path and add exports map

### DIFF
--- a/apps/server/src/index.js
+++ b/apps/server/src/index.js
@@ -4,7 +4,7 @@ import cors from 'cors';
 import http from 'http';
 import { Server } from 'socket.io';
 import rateLimit from 'express-rate-limit';
-import { serverEnv as env } from 'shared/env';
+import { serverEnv as env } from 'shared/env.js';
 import { tokens } from './routes/tokens.js';
 import { health } from './routes/health.js';
 import { taskrouter } from './routes/taskrouter.js';

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,5 +1,9 @@
 {
   "name": "shared",
   "version": "0.1.0",
-  "type": "module"
+  "type": "module",
+  "exports": {
+    "./env": "./env.js",
+    "./auth": "./auth.js"
+  }
 }


### PR DESCRIPTION
## Summary
- fix env import in server to use explicit `.js` extension
- add exports map for shared package to support extensionless imports

## Testing
- `npm install --workspaces`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a76c3ad8c8832a9e91d8dd88111972