### PR TITLE
fix server env import path

### DIFF
--- a/apps/server/src/index.js
+++ b/apps/server/src/index.js
@@ -4,7 +4,7 @@ import cors from 'cors';
 import http from 'http';
 import { Server } from 'socket.io';
 import rateLimit from 'express-rate-limit';
-import { serverEnv as env } from 'shared/env.js';
+import { serverEnv as env } from 'shared/env';
 import { tokens } from './routes/tokens.js';
 import { health } from './routes/health.js';
 import { taskrouter } from './routes/taskrouter.js';


### PR DESCRIPTION
## Summary
- fix env import path to allow package resolution without extension

## Testing
- `npm run dev -w apps/server` (fails: [Twilio] Missing required env(s) for REST client: accountSid, authToken)


------
https://chatgpt.com/codex/tasks/task_e_68a771b27644832a8c2249d67d83e2a0