### PR TITLE
fix softphone import path

### DIFF
--- a/apps/client/src/main.jsx
+++ b/apps/client/src/main.jsx
@@ -2,7 +2,7 @@
 import { createRoot } from 'react-dom/client';
 import { Theme } from '@twilio-paste/core/theme';
 import App from './App.jsx';
-import Softphone from './components/Softphone.jsx';
+import Softphone from './features/softphone/components/Softphone.jsx';
 
 const root = createRoot(document.getElementById('root'));
 


### PR DESCRIPTION
## Summary
- fix softphone import path

## Testing
- `npm run dev -w apps/client` (fails: Bus error)

------
https://chatgpt.com/codex/tasks/task_e_68a7780a5edc832aa02abbe9ca8cdd2a