### PR TITLE
fix: use object syntax for popup style

### DIFF
--- a/apps/client/src/main.jsx
+++ b/apps/client/src/main.jsx
@@ -12,7 +12,7 @@ root.render(
   <Theme.Provider theme="default">
     {isSoftphonePopup ? (
       // Popup renders the Softphone in remoteOnly mode
-      <div style="min-height:100vh;background:var(--paste-color-background-body);padding:16px">
+      <div style={{ minHeight: '100vh', background: 'var(--paste-color-background-body)', padding: '16px' }}>
         <Softphone remoteOnly />
       </div>
     ) : (


### PR DESCRIPTION
## Summary
- render Softphone popup with object-based inline styles

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a77cb9b45c832ab85c23036add1784