### PR TITLE
Use query parameter for softphone popup

### DIFF
--- a/apps/client/src/features/softphone/components/CallControlsModal.jsx
+++ b/apps/client/src/features/softphone/components/CallControlsModal.jsx
@@ -112,7 +112,7 @@ export default function CallControlsModal({ isOpen, onDismiss }) {
 
   const openSoftphonePopout = () => {
     window.open(
-      `${window.location.origin}/#softphone-host`,
+      `${window.location.origin}?popup=softphone`,
       'softphone_popup',
       'width=420,height=640,menubar=no,toolbar=no,resizable=yes,scrollbars=yes,status=no'
     );

--- a/apps/client/src/main.jsx
+++ b/apps/client/src/main.jsx
@@ -6,7 +6,7 @@ import Softphone from './features/softphone/components/Softphone.jsx';
 
 const root = createRoot(document.getElementById('root'));
 
-const isSoftphonePopup = window.location.hash === '#softphone-host';
+const isSoftphonePopup = new URLSearchParams(window.location.search).get('popup') === 'softphone';
 
 root.render(
   <Theme.Provider theme="default">


### PR DESCRIPTION
## Summary
- Detect softphone popup via `?popup=softphone` query string
- Open popup with query string from CallControlsModal
- Confirm softphone hook still targets `?popup=softphone`

## Testing
- `npm test` *(fails: Missing script "test")*
- `node --test apps/server/test/auth.test.js` *(fails: Cannot find module /workspace/TwilioContactCenter/apps/server/src/auth.js)*
- `npm run build` (in apps/client)
- `node -e "const result = new URLSearchParams('?popup=softphone').get('popup') === 'softphone'; console.log('isSoftphonePopup', result);"`


------
https://chatgpt.com/codex/tasks/task_e_68a77dde6b24832aa2b0050c2147c641