### PR TITLE
feat: allow hanging up active calls

### DIFF
--- a/apps/client/src/features/softphone/hooks/useSoftphone.js
+++ b/apps/client/src/features/softphone/hooks/useSoftphone.js
@@ -2,6 +2,8 @@ import { useEffect, useMemo, useRef, useState, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import useLocalStorage from '../../../shared/hooks/useLocalStorage.js';
 import { VoiceDevice } from '../services/VoiceDevice.js';
+import { getCallSid } from '../services/callSidStore.js';
+import Api from '../../index.js';
 
 /**
  * Hook encapsulating VoiceDevice lifecycle, BroadcastChannel sync and call controls
@@ -154,7 +156,9 @@ export default function useSoftphone() {
   async function hangup() {
     try {
       setError('');
+      const sid = getCallSid();
       await dev.disconnect();
+      await Api.hangup(sid);
     } catch {
       setError(t('hangupError'));
     }

--- a/apps/client/src/features/softphone/services/voice.js
+++ b/apps/client/src/features/softphone/services/voice.js
@@ -18,6 +18,9 @@ export const holdStart = (payload) =>
 export const holdStop = (payload) =>
   http.post('/voice/hold/stop', payload).then((r) => r.data);
 
+export const hangup = (callSid) =>
+  http.post('/voice/hangup', { callSid }).then((r) => r.data);
+
 export const recStart = (callSid) =>
   http.post('/voice/recordings/start', { callSid }).then((r) => r.data);
 

--- a/apps/server/src/controllers/voiceControl.js
+++ b/apps/server/src/controllers/voiceControl.js
@@ -1,3 +1,4 @@
+import { rest } from '../twilio.js';
 import {  waitForConferenceByName,
   waitForConferenceBySid,
   waitForParticipantByCallSid,
@@ -95,6 +96,18 @@ export async function holdStop(req, res) {
   } catch (e) {
     console.error('[HOLD/STOP] error', e);
     res.status(500).json({ error: 'cannot unhold', details: e?.message });
+  }
+}
+
+export async function hangupCall(req, res) {
+  try {
+    const { callSid } = req.body || {};
+    if (!callSid) return res.status(400).json({ error: 'missing callSid' });
+    await rest.calls(callSid).update({ status: 'completed' });
+    res.json({ ok: true });
+  } catch (e) {
+    console.error('[HANGUP] error', e);
+    res.status(500).json({ error: 'cannot hangup call', details: e?.message });
   }
 }
 

--- a/apps/server/src/routes/voiceControl.js
+++ b/apps/server/src/routes/voiceControl.js
@@ -3,6 +3,7 @@ import { requireAuth } from 'shared/auth';
 import {
   holdStart,
   holdStop,
+  hangupCall,
   recordingStatus,
   recordingStart,
   recordingPause,
@@ -15,6 +16,7 @@ import {
 export const voiceControl = Router();
 voiceControl.post('/voice/hold/start', requireAuth, holdStart);
 voiceControl.post('/voice/hold/stop', requireAuth, holdStop);
+voiceControl.post('/voice/hangup', requireAuth, hangupCall);
 voiceControl.get('/voice/recordings/status', requireAuth, recordingStatus);
 voiceControl.post('/voice/recordings/start', requireAuth, recordingStart);
 voiceControl.post('/voice/recordings/pause', requireAuth, recordingPause);


### PR DESCRIPTION
## Summary
- add REST controller to end calls and expose POST /voice/hangup
- client softphone calls new API when disconnecting a call

## Testing
- `npm test --workspaces` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68a77eeb30ec832a905292aeb8e9c1c8