### PR TITLE
feat: show finish task button on task card

### DIFF
--- a/apps/client/src/features/tasks/components/TasksPanel.jsx
+++ b/apps/client/src/features/tasks/components/TasksPanel.jsx
@@ -167,6 +167,17 @@ function TaskCard({
               SLA: {formatMMSS(queueSec)} / {formatMMSS(SLA_SECONDS)}
             </Badge>
           </Stack>
+
+          <Tooltip text={translate('finishTaskTooltip')}>
+            <Button
+              aria-label={translate('finishTaskAria')}
+              variant="primary"
+              onClick={() => onFinishPress(t)}
+              disabled={!canFinish}
+            >
+              {translate('finishTask')}
+            </Button>
+          </Tooltip>
         </Stack>
 
         {/* Meta */}
@@ -189,17 +200,6 @@ function TaskCard({
           {/* Call control */}
           <AccordionItem title={translate('callControl')}>
             <Stack orientation={['vertical', 'horizontal']} spacing="space40" style={{ flexWrap: 'wrap' }}>
-              <Tooltip text={translate('finishTaskTooltip')}>
-                <Button
-                  aria-label={translate('finishTaskAria')}
-                  variant="primary"
-                  onClick={() => onFinishPress(t)}
-                  disabled={!canFinish}
-                >
-                  {translate('finishTask')}
-                </Button>
-              </Tooltip>
-
               <Tooltip text={translate('holdTooltip')}>
                 <Button
                   aria-label={translate('holdAria')}


### PR DESCRIPTION
## Summary
- move Finish Task button from call control accordion to the task card header so agents can easily wrap up

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm --workspace apps/client run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a77f182cfc832aba96b358be9c75a9