### PR TITLE
feat: add session restoration endpoint and client init

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,11 @@ VITE_API_BASE=http://localhost:4000/api
 
 Place this in `apps/client/.env` or export it before running `npm run dev -w apps/client`.
 
+Ensure `COOKIE_DOMAIN` and `COOKIE_SECURE` are configured for each environment so
+authentication cookies persist correctly (e.g., use your deployed domain with
+`COOKIE_SECURE=true` in production and `localhost` with `false` during local
+development).
+
 ## Provisioning Twilio Resources
 A helper script creates (or reuses) the TwiML App, TaskRouter workspace, queue, workflow, and basic activities.
 

--- a/apps/client/src/App.jsx
+++ b/apps/client/src/App.jsx
@@ -1,5 +1,5 @@
 // contact-center/client/src/App.jsx
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { IdleTimerProvider } from 'react-idle-timer';
 import { I18nextProvider } from 'react-i18next';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -12,6 +12,13 @@ const queryClient = new QueryClient();
 
 export default function App() {
   const [ctx, setCtx] = useState(null);
+  useEffect(() => {
+    Api.me()
+      .then(data => {
+        if (data?.agent) setCtx({ agent: data.agent });
+      })
+      .catch(() => {});
+  }, []);
   if (!ctx) return <Login onReady={setCtx} />;
 
   const onIdle = async () => {

--- a/apps/client/src/features/auth/services/auth.js
+++ b/apps/client/src/features/auth/services/auth.js
@@ -4,3 +4,5 @@ export const login = (agentId, workerSid, identity) =>
   http.post('/auth/login', { agentId, workerSid, identity }).then((r) => r.data);
 
 export const logout = () => http.post('/auth/logout');
+
+export const me = () => http.get('/auth/me').then(r => r.data);

--- a/apps/server/src/controllers/tokens.js
+++ b/apps/server/src/controllers/tokens.js
@@ -70,6 +70,17 @@ export async function login(req, res) {
   }
 }
 
+export function me(req, res) {
+  const token = getCookie(req, env.refreshTokenName);
+  if (!token || !refreshTokens.has(token)) {
+    return res.status(401).json({ error: 'invalid refresh token' });
+  }
+  const { agentId, workerSid, identity } = refreshTokens.get(token);
+  const access = signAgentToken(agentId, workerSid, identity);
+  res.cookie(env.accessTokenName, access, accessCookieOpts);
+  return res.json({ agent: { id: agentId, workerSid, identity } });
+}
+
 export function refresh(req, res) {
   const token = getCookie(req, env.refreshTokenName);
   if (!token || !refreshTokens.has(token)) {

--- a/apps/server/src/routes/tokens.js
+++ b/apps/server/src/routes/tokens.js
@@ -1,11 +1,12 @@
 ﻿import { Router } from 'express';
 import { requireAuth } from 'shared/auth';
-import { login, refresh, logout, voiceToken, workerToken } from '../controllers/tokens.js';
+import { login, me, refresh, logout, voiceToken, workerToken } from '../controllers/tokens.js';
 
 export const tokens = Router();
 tokens.post('/auth/login', login);
 tokens.post('/auth/refresh', refresh);
 tokens.post('/auth/logout', logout);
+tokens.get('/auth/me', requireAuth, me);
 tokens.get('/token/voice', requireAuth, voiceToken);
 tokens.get('/token/tr-worker', requireAuth, workerToken);
 


### PR DESCRIPTION
## Summary
- add `/auth/me` endpoint to issue fresh access tokens and return the current agent
- call `Api.me()` on client init to skip login when session cookies are present
- document cookie domain/secure environment variables

## Testing
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_68a79923538c832aa7a7ad1c6a080e00