### PR TITLE
Reset refresh promise on failed auth refresh

### DIFF
--- a/apps/client/src/shared/services/http.js
+++ b/apps/client/src/shared/services/http.js
@@ -18,7 +18,8 @@ http.interceptors.response.use(
         refreshPromise = null;
         return http(config);
       } catch {
-        window.location.reload();
+        refreshPromise = null;
+        return Promise.reject(err);
       }
     }
     return Promise.reject(err);


### PR DESCRIPTION
## Summary
- Avoid page reload when token refresh fails by rejecting the promise
- Reset `refreshPromise` before rejecting to prevent repeated refresh attempts

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: Missing script: "lint")

------
https://chatgpt.com/codex/tasks/task_e_68a79d7beb60832a9cdb11ba417ee62a