### PR TITLE
feat: support remote-only softphone control

### DIFF
--- a/apps/client/src/features/softphone/components/Softphone.jsx
+++ b/apps/client/src/features/softphone/components/Softphone.jsx
@@ -39,7 +39,7 @@ export default function Softphone({ remoteOnly }) {
     rejectIncoming,
     sendDtmf,
     openPopOut,
-  } = useSoftphone();
+  } = useSoftphone(remoteOnly);
 
   const [isDtmfOpen, setIsDtmfOpen] = useState(false);
 

--- a/apps/client/src/main.jsx
+++ b/apps/client/src/main.jsx
@@ -7,13 +7,14 @@ import Softphone from './features/softphone/components/Softphone.jsx';
 const root = createRoot(document.getElementById('root'));
 
 const isSoftphonePopup = new URLSearchParams(window.location.search).get('popup') === 'softphone';
+const remoteOnly = isSoftphonePopup;
 
 root.render(
   <Theme.Provider theme="default">
-    {isSoftphonePopup ? (
+    {remoteOnly ? (
       // Popup renders the Softphone in remoteOnly mode
       <div style={{ minHeight: '100vh', background: 'var(--paste-color-background-body)', padding: '16px' }}>
-        <Softphone remoteOnly />
+        <Softphone remoteOnly={remoteOnly} />
       </div>
     ) : (
       <App />


### PR DESCRIPTION
## Summary
- add remote-only mode to softphone hook that proxies actions via BroadcastChannel
- plumb remoteOnly flag from main to Softphone hook

## Testing
- `npm test` (fails: Missing script)
- `npm run build` (fails: vite: not found)


------
https://chatgpt.com/codex/tasks/task_e_68a7a07ae794832a9dd273d4175bbae4