### PR TITLE
Clear incoming state after softphone call actions

### DIFF
--- a/apps/client/src/features/softphone/hooks/useSoftphone.js
+++ b/apps/client/src/features/softphone/hooks/useSoftphone.js
@@ -223,6 +223,7 @@ export default function useSoftphone(remoteOnly = false) {
       sendCmd('hangup');
       setCallStatus('Idle');
       setIsMuted(false);
+      setIncoming(null);
       return;
     }
     try {
@@ -235,6 +236,7 @@ export default function useSoftphone(remoteOnly = false) {
     }
     setCallStatus('Idle');
     setIsMuted(false);
+    setIncoming(null);
     setTimeout(() => publishStateRef.current(), 0);
   }
 
@@ -258,17 +260,20 @@ export default function useSoftphone(remoteOnly = false) {
     if (isPopup) {
       sendCmd('accept');
       setIncomingOpen(false);
+      setIncoming(null);
       return;
     }
     try {
       setError('');
       await incoming?.accept();
       setIncomingOpen(false);
+      setIncoming(null);
       setCallStatus('In Call');
     } catch {
       setError(t('acceptError'));
       setIncomingOpen(false);
       setCallStatus('Idle');
+      setIncoming(null);
     }
     setTimeout(() => publishStateRef.current(), 0);
   }
@@ -277,6 +282,7 @@ export default function useSoftphone(remoteOnly = false) {
     if (isPopup) {
       sendCmd('reject');
       setIncomingOpen(false);
+      setIncoming(null);
       return;
     }
     try {
@@ -287,6 +293,7 @@ export default function useSoftphone(remoteOnly = false) {
     }
     setIncomingOpen(false);
     setCallStatus('Idle');
+    setIncoming(null);
     setTimeout(() => publishStateRef.current(), 0);
   }
 


### PR DESCRIPTION
## Summary
- Reset `incoming` state on accept, reject, and hangup to ensure call popup doesn't reappear
- Guaranteed `publishState` sends `hasIncoming: false` once the call is handled

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a7d0aee7dc832aa54b1e652ceef9f0