### PR TITLE
Handle cancelled incoming calls

### DIFF
--- a/apps/client/src/features/softphone/services/VoiceDevice.js
+++ b/apps/client/src/features/softphone/services/VoiceDevice.js
@@ -100,6 +100,14 @@ export class VoiceDevice {
       this._status('Idle');
     });
 
+    call.on('cancel', () => {
+      console.log('Call cancelled');
+      setCallSid(null);
+      if (this.current === call) this.current = undefined;
+      this._status('Idle');
+      this.onIncoming?.(null);
+    });
+
     call.on('error', (e) => {
       console.error('Call error', e);
       setCallSid(null);


### PR DESCRIPTION
## Summary
- reset state when a call is cancelled before being answered

## Testing
- `npm test` *(fails: Missing script "test")*
- `cd apps/client && npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a7d4a504f0832a89bff4320fc0b8ca