### PR TITLE
Persist call SID across tabs via localStorage

### DIFF
--- a/apps/client/src/features/softphone/services/callSidStore.js
+++ b/apps/client/src/features/softphone/services/callSidStore.js
@@ -1,4 +1,28 @@
 // contact-center/client/src/softphone/callSidStore.js
 let _sid = null;
-export const setCallSid = (v) => { _sid = v || null; };
-export const getCallSid = () => _sid;
+const KEY = 'callSid';
+
+// Sync _sid when another tab updates the value
+try {
+  window.addEventListener('storage', (e) => {
+    if (e.key === KEY) {
+      _sid = e.newValue || null;
+    }
+  });
+} catch {}
+
+export const setCallSid = (v) => {
+  _sid = v || null;
+  try {
+    if (_sid) window.localStorage.setItem(KEY, _sid);
+    else window.localStorage.removeItem(KEY);
+  } catch {}
+};
+
+export const getCallSid = () => {
+  if (_sid) return _sid;
+  try {
+    _sid = window.localStorage.getItem(KEY) || null;
+  } catch {}
+  return _sid;
+};


### PR DESCRIPTION
## Summary
- persist call SID to `localStorage` and keep in-memory `_sid` in sync across tabs using the `storage` event
- load SID from `localStorage` when memory is empty so each tab shares the same active call

## Testing
- `npm run build`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a7dd8abe70832aab83098dc02790c8