### PR TITLE
Persist call SID across softphone state sync

### DIFF
--- a/apps/client/src/features/softphone/hooks/useSoftphone.js
+++ b/apps/client/src/features/softphone/hooks/useSoftphone.js
@@ -58,6 +58,7 @@ export default function useSoftphone(remoteOnly = false) {
   const publishState = useCallback(() => {
     if (isPopup) return;
     try {
+      const sid = getCallSid();
       chanRef.current?.postMessage({
         type: 'state',
         payload: {
@@ -67,7 +68,7 @@ export default function useSoftphone(remoteOnly = false) {
           to,
           elapsed,
           hasIncoming: !!incoming,
-          callSid: getCallSid(),
+          callSid: sid,
         },
       });
     } catch (e) {
@@ -219,8 +220,11 @@ export default function useSoftphone(remoteOnly = false) {
           setTo(payload.to || '');
           setIncoming(payload.hasIncoming ? {} : null);
           setIncomingOpen(!!payload.hasIncoming);
-          if (payload.callStatus === 'Idle') setCallSid(null);
-          else setCallSid(payload.callSid);
+          if (payload.callStatus === 'Idle') {
+            setCallSid(null);
+          } else if (payload.callSid) {
+            setCallSid(payload.callSid);
+          }
           if (payload.elapsed) {
             const [m, s] = String(payload.elapsed).split(':').map((x) => parseInt(x, 10) || 0);
             const sec = m * 60 + s;


### PR DESCRIPTION
## Summary
- broadcast call SID in softphone state updates
- save and clear call SID in popup based on state messages

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a7e05286bc832abd56c66759701350