### PR TITLE
Clear call SID from shared storage on call end

### DIFF
--- a/apps/client/src/features/softphone/hooks/useSoftphone.js
+++ b/apps/client/src/features/softphone/hooks/useSoftphone.js
@@ -222,8 +222,8 @@ export default function useSoftphone(remoteOnly = false) {
           setIncomingOpen(!!payload.hasIncoming);
           if (payload.callStatus === 'Idle') {
             setCallSid(null);
-          } else if (payload.callSid) {
-            setCallSid(payload.callSid);
+          } else {
+            setCallSid(payload.callSid || null);
           }
           if (payload.elapsed) {
             const [m, s] = String(payload.elapsed).split(':').map((x) => parseInt(x, 10) || 0);

--- a/apps/client/src/features/softphone/services/VoiceDevice.js
+++ b/apps/client/src/features/softphone/services/VoiceDevice.js
@@ -96,6 +96,7 @@ export class VoiceDevice {
     call.on('disconnect', () => {
       console.log('Call ended');
       setCallSid(null);
+      try { window.localStorage.removeItem('callSid'); } catch {}
       if (this.current === call) this.current = undefined;
       this._status('Idle');
     });
@@ -103,6 +104,7 @@ export class VoiceDevice {
     call.on('cancel', () => {
       console.log('Call cancelled');
       setCallSid(null);
+      try { window.localStorage.removeItem('callSid'); } catch {}
       if (this.current === call) this.current = undefined;
       this._status('Idle');
       this.onIncoming?.(null);
@@ -111,6 +113,7 @@ export class VoiceDevice {
     call.on('error', (e) => {
       console.error('Call error', e);
       setCallSid(null);
+      try { window.localStorage.removeItem('callSid'); } catch {}
       this._status('Idle');
     });
   }


### PR DESCRIPTION
## Summary
- ensure call SID removed from local storage on disconnect, cancel, or error
- propagate cleared call SID to popup when state is idle

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a7e1dcc420832ab0f5888a7a1d5438