### PR TITLE
feat: hang up active call on unload

### DIFF
--- a/apps/client/src/features/softphone/hooks/useSoftphone.js
+++ b/apps/client/src/features/softphone/hooks/useSoftphone.js
@@ -316,6 +316,24 @@ export default function useSoftphone(remoteOnly = false) {
   useEffect(() => { if (!isPopup) publishState(); }, [publishState, isPopup]);
 
   useEffect(() => {
+    if (isPopup) return undefined;
+    const hangupOnUnload = () => {
+      try {
+        const sid = getCallSid();
+        if (sid) Api.hangup(sid);
+      } catch (e) {
+        console.warn('[softphone unload hangup error]', e);
+      }
+    };
+    window.addEventListener('beforeunload', hangupOnUnload);
+    window.addEventListener('unload', hangupOnUnload);
+    return () => {
+      window.removeEventListener('beforeunload', hangupOnUnload);
+      window.removeEventListener('unload', hangupOnUnload);
+    };
+  }, [isPopup]);
+
+  useEffect(() => {
     if (!isPopup) return undefined;
     const notifyClose = () => {
       try {


### PR DESCRIPTION
## Summary
- ensure non-popup softphone cleans up active call on window close

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a7e2e0fa98832a884f90b8135c50d3