### PR TITLE
feat(chat): refresh conversations token

### DIFF
--- a/apps/server/src/routes/chat-token.route.js
+++ b/apps/server/src/routes/chat-token.route.js
@@ -17,5 +17,20 @@ res.status(500).json({ error: e.message });
 }
 });
 
+// Refresh an SDK token before or after it expires
+router.get('/refresh', (req, res) => {
+  const { identity } = req.query;
+  if (!identity) {
+    res.status(400).json({ error: 'identity is required' });
+    return;
+  }
+  try {
+    const token = createConversationsToken(identity, 3600); // 1 hour TTL
+    res.json({ token });
+  } catch (e) {
+    res.status(500).json({ error: e.message });
+  }
+});
+
 
 export default router;


### PR DESCRIPTION
## Summary
- add `/api/chat/refresh` endpoint to issue new Conversations tokens
- refresh Conversations token in ChatWidget when it expires

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a7f70e4334832aafb014358cfdc03e