### PR TITLE
Create and complete tasks from conversation webhooks

### DIFF
--- a/apps/server/src/routes/conversations-webhooks.route.js
+++ b/apps/server/src/routes/conversations-webhooks.route.js
@@ -1,17 +1,46 @@
 import express from 'express';
-
+import { createTask, completeTask, pushEvent } from '../services/taskrouter.js';
 
 const router = express.Router();
-
+const tasksByConversation = new Map();
 
 // Twilio will POST events like onMessageAdded here if you attach a webhook per‑conversation.
-router.post('/', (req, res) => {
-// TODO: validate X-Twilio-Signature unless SKIP_TWILIO_VALIDATION=true (dev only)
-const eventType = req.body.EventType || req.body.EventType?.toString();
-console.log('[Conversations Webhook]', eventType, req.body?.MessageSid || '');
-// Example: forward to Socket.IO or persist in DB
-res.status(200).send('ok');
+router.post('/', async (req, res) => {
+  // TODO: validate X-Twilio-Signature unless SKIP_TWILIO_VALIDATION=true (dev only)
+  const eventType = req.body.EventType || req.body.EventType?.toString();
+  console.log('[Conversations Webhook]', eventType, req.body?.MessageSid || '');
+  const io = req.app.get('io');
+  try {
+    if (eventType === 'onConversationAdded') {
+      const source = String(req.body.Source || '').toLowerCase();
+      if (!['api', 'sdk'].includes(source)) {
+        const conversationSid = req.body.ConversationSid;
+        const task = await createTask({
+          attributes: { channel: 'chat', conversationSid, direction: 'inbound' },
+          taskChannel: 'chat'
+        });
+        tasksByConversation.set(conversationSid, task.sid);
+        pushEvent('TASK_CREATED', { taskSid: task.sid, conversationSid });
+        io?.emit('task_created', { taskSid: task.sid, conversationSid });
+      }
+    } else if (eventType === 'onConversationStateUpdated') {
+      const status = String(req.body.Status || '').toLowerCase();
+      if (status === 'closed') {
+        const conversationSid = req.body.ConversationSid;
+        const taskSid = tasksByConversation.get(conversationSid);
+        if (taskSid) {
+          await completeTask(taskSid, 'Conversation closed');
+          pushEvent('TASK_COMPLETED', { taskSid, conversationSid });
+          io?.emit('task_completed', { taskSid, conversationSid });
+          tasksByConversation.delete(conversationSid);
+        }
+      }
+    }
+    res.status(200).send('ok');
+  } catch (e) {
+    console.error('[Conversations Webhook] error:', e);
+    res.status(500).send('error');
+  }
 });
-
 
 export default router;

--- a/apps/server/src/services/taskrouter.js
+++ b/apps/server/src/services/taskrouter.js
@@ -14,6 +14,16 @@ export const fetchTask = (taskSid) =>
 export const updateTask = (taskSid, payload) =>
   rest.taskrouter.v1.workspaces(env.workspaceSid).tasks(taskSid).update(payload);
 
+export function createTask({ attributes = {}, taskChannel, ...opts } = {}) {
+  const attrs = typeof attributes === 'string' ? attributes : JSON.stringify(attributes);
+  const payload = { attributes: attrs, workflowSid: env.workflowSid, ...opts };
+  if (taskChannel) payload.taskChannel = taskChannel;
+  return rest.taskrouter.v1.workspaces(env.workspaceSid).tasks.create(payload);
+}
+
+export const completeTask = (taskSid, reason = 'Conversation closed') =>
+  updateTask(taskSid, { assignmentStatus: 'completed', reason });
+
 export const listWorkers = () =>
   rest.taskrouter.v1.workspaces(env.workspaceSid).workers.list({ limit: 200 });
 


### PR DESCRIPTION
## Summary
- Create chat tasks when Conversations webhook reports a new conversation from non-API/SDK sources
- Complete related tasks when conversation is closed
- Expose task helper methods for creating and completing tasks

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68a7f8d833f0832a9891969b58629677