### PR TITLE
Enable Conversations webhook header for REST messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,12 @@ npm start -w apps/server
 
 Default port: `4000`. The server exposes REST endpoints under `/api/*` and uses Socket.IO for presence updates.
 
+### Conversations REST messaging
+The server's Conversations helper uses Twilio's REST API to send messages. It sets the
+`X-Twilio-Webhook-Enabled: true` header so that Twilio triggers any configured
+webhooks after a message is sent programmatically. Include this header only when
+you need to receive the webhook following a REST send.
+
 ## Web Client
 A React application built with Vite and Twilio Paste components. It communicates with the server via REST and WebSocket and embeds the Twilio Voice SDK & TaskRouter JS SDK.
 

--- a/apps/server/src/conversations/service.js
+++ b/apps/server/src/conversations/service.js
@@ -72,13 +72,24 @@ return client.conversations.v1.conversations(conversationSid).participants.creat
 }
 
 
-/** Send a message (works for all channels) */
-export function sendMessage(conversationSid, { author = 'system', body, mediaSid, attributes }) {
-const payload = { author };
-if (body) payload.body = body;
-if (mediaSid) payload.mediaSid = mediaSid;
-if (attributes) payload.attributes = JSON.stringify(attributes);
-return client.conversations.v1.conversations(conversationSid).messages.create(payload);
+/**
+ * Send a message (works for all channels).
+ *
+ * The `xTwilioWebhookEnabled` option instructs Twilio to fire any configured
+ * Conversation webhooks even though the message was sent via REST. Use this
+ * header only when a webhook callback is desired after a REST send.
+ */
+export function sendMessage(
+  conversationSid,
+  { author = 'system', body, mediaSid, attributes }
+) {
+  const payload = { author };
+  if (body) payload.body = body;
+  if (mediaSid) payload.mediaSid = mediaSid;
+  if (attributes) payload.attributes = JSON.stringify(attributes);
+  return client.conversations.v1
+    .conversations(conversationSid)
+    .messages.create(payload, { xTwilioWebhookEnabled: true });
 }
 
 


### PR DESCRIPTION
## Summary
- send REST Conversation messages with `xTwilioWebhookEnabled` so Twilio fires webhooks
- document when to use the `X-Twilio-Webhook-Enabled` header

## Testing
- `npm test -w apps/server` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a7fb66bacc832a95fef2bfe75b8c10