### PR TITLE
feat: configure conversation timers and allow manual hang up

### DIFF
--- a/apps/server/src/routes/conversations.route.js
+++ b/apps/server/src/routes/conversations.route.js
@@ -7,6 +7,7 @@ addWhatsappParticipant,
 addMessengerParticipant,
 sendMessage,
 attachWebhook,
+updateConversationTimers,
 } from '../conversations/service.js';
 
 
@@ -68,6 +69,18 @@ const { sid } = req.params;
 try {
 const msg = await sendMessage(sid, req.body);
 res.json(msg);
+} catch (e) {
+res.status(500).json({ error: e.message });
+}
+});
+
+
+// Update conversation timers (e.g., to hang up)
+router.post('/:sid/timers', async (req, res) => {
+const { sid } = req.params;
+try {
+const convo = await updateConversationTimers(sid, req.body);
+res.json(convo);
 } catch (e) {
 res.status(500).json({ error: e.message });
 }


### PR DESCRIPTION
## Summary
- set default inactive/closed timers when creating conversations
- add endpoint to update conversation timers for chat hang up

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a7fbf85b48832aa82545e84842e6ae