### PR TITLE
fix: correct twilio import for ESM

### DIFF
--- a/apps/server/src/conversations/tokens.js
+++ b/apps/server/src/conversations/tokens.js
@@ -1,7 +1,7 @@
-import { jwt } from 'twilio';
+import twilio from 'twilio';
 
 
-const { AccessToken } = jwt;
+const { AccessToken } = twilio.jwt;
 const { ChatGrant } = AccessToken; // Conversations uses ChatGrant with serviceSid
 
 


### PR DESCRIPTION
## Summary
- use default Twilio import to access `jwt.AccessToken` and `ChatGrant`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a7fcfdeb24832abf9fb35aa3c7a830