### PR TITLE
Add webchat sample and propagate conversation attributes to tasks

### DIFF
--- a/apps/server/src/routes/conversations-webhooks.route.js
+++ b/apps/server/src/routes/conversations-webhooks.route.js
@@ -15,8 +15,15 @@ router.post('/', async (req, res) => {
       const source = String(req.body.Source || '').toLowerCase();
       if (!['api', 'sdk'].includes(source)) {
         const conversationSid = req.body.ConversationSid;
+        const convo = await fetchConversation(conversationSid);
+        const convoAttrs = convo.attributes ? JSON.parse(convo.attributes) : {};
         const task = await createTask({
-          attributes: { channel: 'chat', conversationSid, direction: 'inbound' },
+          attributes: {
+            channel: 'chat',
+            conversationSid,
+            direction: 'inbound',
+            ...convoAttrs
+          },
           taskChannel: 'chat'
         });
         await updateConversationAttributes(conversationSid, { taskSid: task.sid });

--- a/samples/webchat/chat.js
+++ b/samples/webchat/chat.js
@@ -1,0 +1,60 @@
+(async function () {
+  const startForm = document.getElementById('start-form');
+  const chatContainer = document.getElementById('chat-container');
+  const messagesEl = document.getElementById('messages');
+  const messageForm = document.getElementById('message-form');
+  const messageInput = document.getElementById('message-input');
+
+  let conversation;
+
+  startForm.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const name = document.getElementById('name').value;
+    const email = document.getElementById('email').value;
+
+    // Create conversation with attributes
+    const convoRes = await fetch('/api/conversations', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ attributes: { name, email } })
+    });
+    const convoData = await convoRes.json();
+
+    // Fetch token for Conversations SDK
+    const tokenRes = await fetch('/api/chat/token');
+    const { token, identity } = await tokenRes.json();
+
+    // Add this user as chat participant
+    await fetch(`/api/conversations/${convoData.sid}/participants`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        type: 'chat',
+        identity,
+        attributes: { name, email }
+      })
+    });
+
+    // Initialize Conversations client and join
+    const client = await Twilio.Conversations.Client.create(token);
+    conversation = await client.getConversationBySid(convoData.sid);
+    await conversation.join();
+
+    startForm.style.display = 'none';
+    chatContainer.style.display = 'block';
+
+    conversation.on('messageAdded', (msg) => {
+      const li = document.createElement('li');
+      li.textContent = `${msg.author}: ${msg.body}`;
+      messagesEl.appendChild(li);
+    });
+  });
+
+  messageForm.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const body = messageInput.value;
+    if (!body || !conversation) return;
+    await conversation.sendMessage(body);
+    messageInput.value = '';
+  });
+})();

--- a/samples/webchat/index.html
+++ b/samples/webchat/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Webchat Sample</title>
+</head>
+<body>
+  <h1>Webchat Demo</h1>
+  <form id="start-form">
+    <input id="name" type="text" placeholder="Name" required>
+    <input id="email" type="email" placeholder="Email" required>
+    <button type="submit">Start Chat</button>
+  </form>
+
+  <div id="chat-container" style="display:none;">
+    <ul id="messages"></ul>
+    <form id="message-form">
+      <input id="message-input" type="text" placeholder="Type a message" autocomplete="off" />
+      <button type="submit">Send</button>
+    </form>
+  </div>
+
+  <script src="https://media.twiliocdn.com/sdk/js/conversations/v2.4/conversations.min.js"></script>
+  <script src="chat.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add webchat sample that creates a conversation and joins via SDK
- include conversation attributes when creating TaskRouter tasks

## Testing
- `cd apps/server && npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a7feac055c832ab3906ccca78602d4