### PR TITLE
Add webchat sample and include conversation attributes in TaskRouter tasks

### DIFF
--- a/apps/server/src/routes/conversations-webhooks.route.js
+++ b/apps/server/src/routes/conversations-webhooks.route.js
@@ -15,8 +15,15 @@ router.post('/', async (req, res) => {
       const source = String(req.body.Source || '').toLowerCase();
       if (!['api', 'sdk'].includes(source)) {
         const conversationSid = req.body.ConversationSid;
+        const convo = await fetchConversation(conversationSid);
+        const convoAttrs = convo.attributes ? JSON.parse(convo.attributes) : {};
         const task = await createTask({
-          attributes: { channel: 'chat', conversationSid, direction: 'inbound' },
+          attributes: {
+            channel: 'chat',
+            conversationSid,
+            direction: 'inbound',
+            ...convoAttrs
+          },
           taskChannel: 'chat'
         });
         await updateConversationAttributes(conversationSid, { taskSid: task.sid });

--- a/samples/webchat/chat.js
+++ b/samples/webchat/chat.js
@@ -1,0 +1,47 @@
+async function startChat(event) {
+  event.preventDefault();
+  const name = document.getElementById('name').value;
+  const email = document.getElementById('email').value;
+
+  // Fetch an SDK token
+  const tokenResp = await fetch('/api/chat/token');
+  const { token, identity } = await tokenResp.json();
+
+  // Create a new Conversation with attributes
+  const uniqueName = `web-${crypto.randomUUID()}`;
+  const convoResp = await fetch('/api/conversations', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      uniqueName,
+      friendlyName: name,
+      attributes: { name, email }
+    })
+  });
+  const conversation = await convoResp.json();
+
+  // Add this browser as a chat participant
+  await fetch(`/api/conversations/${conversation.sid}/participants`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      type: 'chat',
+      identity,
+      attributes: { name, email }
+    })
+  });
+
+  // Initialize the Conversations SDK and join
+  const client = await Twilio.ConversationsClient.create(token);
+  const convo = await client.getConversationBySid(conversation.sid);
+  try {
+    await convo.join();
+  } catch (err) {
+    // ignore if already joined
+  }
+  document.getElementById('chat-form').style.display = 'none';
+  document.getElementById('chat').style.display = 'block';
+  console.log('Joined conversation', convo.sid);
+}
+
+document.getElementById('chat-form').addEventListener('submit', startChat);

--- a/samples/webchat/index.html
+++ b/samples/webchat/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>WebChat Sample</title>
+</head>
+<body>
+  <form id="chat-form">
+    <label>
+      Name:
+      <input id="name" type="text" required />
+    </label>
+    <label>
+      Email:
+      <input id="email" type="email" required />
+    </label>
+    <button type="submit">Start Chat</button>
+  </form>
+  <div id="chat" style="display:none;"></div>
+  <script src="https://media.twiliocdn.com/sdk/js/conversations/v1.4/conversations.min.js"></script>
+  <script src="./chat.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add simple browser-based webchat sample using Twilio Conversations
- pass conversation attributes like name and email when creating TaskRouter tasks

## Testing
- `npm test`
- `npm --prefix apps/server test`


------
https://chatgpt.com/codex/tasks/task_e_68a7feb5a814832ab44f39b525d0b606