### PR TITLE
feat(chat): track unread counts and show unread badges

### DIFF
--- a/apps/client/src/chat/ChatPanel.jsx
+++ b/apps/client/src/chat/ChatPanel.jsx
@@ -2,10 +2,17 @@ import { useState, useEffect } from 'react';
 import { Tabs, TabList, Tab, TabPanels, TabPanel } from '@twilio-paste/core/tabs';
 import { Box } from '@twilio-paste/core/box';
 import { Button } from '@twilio-paste/core/button';
+import { Badge } from '@twilio-paste/core/badge';
 import { CloseIcon } from '@twilio-paste/icons/esm/CloseIcon';
 import ChatWidget from './ChatWidget.jsx';
 
-export default function ChatPanel({ sessions = [], onClose }) {
+export default function ChatPanel({
+  sessions = [],
+  onClose,
+  onIncrementUnread,
+  onClearUnread,
+  onLabel,
+}) {
   const [activeTab, setActiveTab] = useState(sessions[0]?.sid);
 
   useEffect(() => {
@@ -19,15 +26,23 @@ export default function ChatPanel({ sessions = [], onClose }) {
   if (sessions.length === 0) return null;
 
   return (
-    <Tabs selectedId={activeTab} onTabChange={setActiveTab}>
+    <Tabs
+      selectedId={activeTab}
+      onTabChange={(id) => {
+        setActiveTab(id);
+        onClearUnread?.(id);
+      }}
+    >
       <TabList aria-label="Active chats">
         {sessions.map((s) => (
           <Tab key={s.sid} id={s.sid}>
             <Box display="flex" alignItems="center" columnGap="space20">
-              <Box as="span">
-                {s.label}
-                {s.unread > 0 ? ` (${s.unread})` : ''}
-              </Box>
+              <Box as="span">{s.label}</Box>
+              {s.unread > 0 && (
+                <Badge as="span" variant="new">
+                  {s.unread}
+                </Badge>
+              )}
               <Button
                 size="reset"
                 variant="link"
@@ -45,7 +60,16 @@ export default function ChatPanel({ sessions = [], onClose }) {
       <TabPanels>
         {sessions.map((s) => (
           <TabPanel key={s.sid} id={s.sid}>
-            <ChatWidget conversationIdOrUniqueName={s.sid} />
+            <ChatWidget
+              conversationIdOrUniqueName={s.sid}
+              isActive={activeTab === s.sid}
+              onMessageAdded={() =>
+                s.sid === activeTab
+                  ? onClearUnread?.(s.sid)
+                  : onIncrementUnread?.(s.sid)
+              }
+              onLabel={(label) => onLabel?.(s.sid, label)}
+            />
           </TabPanel>
         ))}
       </TabPanels>

--- a/apps/client/src/features/tasks/components/AgentApp.jsx
+++ b/apps/client/src/features/tasks/components/AgentApp.jsx
@@ -118,6 +118,21 @@ export default function AgentApp() {
     };
   }, [worker]);
 
+  const incrementUnread = (sid) =>
+    setChatSessions((prev) =>
+      prev.map((s) => (s.sid === sid ? { ...s, unread: (s.unread || 0) + 1 } : s))
+    );
+
+  const clearUnread = (sid) =>
+    setChatSessions((prev) =>
+      prev.map((s) => (s.sid === sid ? { ...s, unread: 0 } : s))
+    );
+
+  const updateLabel = (sid, label) =>
+    setChatSessions((prev) =>
+      prev.map((s) => (s.sid === sid ? { ...s, label } : s))
+    );
+
   const sections = [
     { id: 'softphone', label: 'Softphone', content: () => <Softphone popupOpen={isSoftphonePopout} /> },
     { id: 'presence', label: 'Presence', content: () => <Presence /> },
@@ -212,6 +227,9 @@ export default function AgentApp() {
             onClose={(sid) =>
               setChatSessions((prev) => prev.filter((s) => s.sid !== sid))
             }
+            onIncrementUnread={incrementUnread}
+            onClearUnread={clearUnread}
+            onLabel={updateLabel}
           />
         </Box>
       )}


### PR DESCRIPTION
## Summary
- track unread messages in each chat widget
- display unread badges and dynamic labels in chat panel tabs
- manage unread counts and labels from agent app

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build --workspace apps/client`


------
https://chatgpt.com/codex/tasks/task_e_68a8013300cc832aa608c397259a2ae5