### PR TITLE
feat(samples): make webchat API base configurable

### DIFF
--- a/samples/webchat/chat.js
+++ b/samples/webchat/chat.js
@@ -1,3 +1,5 @@
+const API_BASE = window.API_BASE || 'http://localhost:4000';
+
 (async function () {
   const startForm = document.getElementById('start-form');
   const chatContainer = document.getElementById('chat-container');
@@ -13,7 +15,7 @@
     const email = document.getElementById('email').value;
 
     // Create conversation with attributes
-    const convoRes = await fetch('/api/conversations', {
+    const convoRes = await fetch(`${API_BASE}/api/conversations`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ attributes: { name, email } })
@@ -21,11 +23,11 @@
     const convoData = await convoRes.json();
 
     // Fetch token for Conversations SDK
-    const tokenRes = await fetch('/api/chat/token');
+    const tokenRes = await fetch(`${API_BASE}/api/chat/token`);
     const { token, identity } = await tokenRes.json();
 
     // Add this user as chat participant
-    await fetch(`/api/conversations/${convoData.sid}/participants`, {
+    await fetch(`${API_BASE}/api/conversations/${convoData.sid}/participants`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({


### PR DESCRIPTION
## Summary
- allow configuring base URL for webchat sample API calls
- build request URLs using API_BASE for conversations, token, and participant APIs

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a86b6daba4832aa128163a3b7a93f9