### PR TITLE
chore: set webchat API base URL

### DIFF
--- a/samples/webchat/index.html
+++ b/samples/webchat/index.html
@@ -22,6 +22,9 @@
   </div>
 
   <script src="https://media.twiliocdn.com/sdk/js/conversations/v2.4/conversations.min.js"></script>
+  <script>
+    window.API_BASE = 'http://localhost:4000'; // adjust as needed
+  </script>
   <script src="chat.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- allow configuring API base URL in webchat sample

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a86c0888f4832ab2ece1b0e72b64af