### PR TITLE
Scope CRM authentication to /crm routes

### DIFF
--- a/apps/server/src/routes/crm.js
+++ b/apps/server/src/routes/crm.js
@@ -13,7 +13,7 @@ import {
 } from '../controllers/crm.js';
 
 export const crmProxy = Router();
-crmProxy.use(requireAuth);
+crmProxy.use('/crm', requireAuth);
 crmProxy.get('/crm/vehicles/by-id/:id', getVehicleById);
 crmProxy.get('/crm/customers/:id', getCustomerById);
 crmProxy.get('/crm/vehicles/by-plate/:plate', getVehicleByPlate);


### PR DESCRIPTION
## Summary
- protect only /crm paths by scoping the CRM router's authentication middleware
- confirm CRM router remains mounted under /api so endpoints stay /api/crm/...

## Testing
- `npm test` *(fails: Missing script: "test")*
- `cd apps/server && npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a86e6b329c832ab3b2c0e07c4b47e6