### PR TITLE
feat(webchat): send uniqueName when creating conversation

### DIFF
--- a/samples/webchat/chat.js
+++ b/samples/webchat/chat.js
@@ -18,7 +18,10 @@ const API_BASE = window.API_BASE || 'http://localhost:4000';
     const convoRes = await fetch(`${API_BASE}/api/conversations`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ attributes: { name, email } })
+      body: JSON.stringify({
+        uniqueName: email,
+        attributes: { name, email }
+      })
     });
     if (!convoRes.ok) {
       alert('Failed to create conversation');


### PR DESCRIPTION
## Summary
- send `uniqueName` with initial conversation creation in webchat sample to ensure server associates requests with existing conversations

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: Missing script: "lint")

------
https://chatgpt.com/codex/tasks/task_e_68a870891ee8832a8c1ee88b2c7edbd2