### PR TITLE
fix: expose Twilio global for webchat

### DIFF
--- a/samples/webchat/index.html
+++ b/samples/webchat/index.html
@@ -21,7 +21,7 @@
     </form>
   </div>
 
-  <script src="https://media.twiliocdn.com/sdk/js/conversations/v2.4/conversations.min.js"></script>
+  <script src="https://media.twiliocdn.com/sdk/js/conversations/v2.4/twilio-conversations.min.js"></script>
   <script>
     window.API_BASE = 'http://localhost:4000'; // adjust as needed
   </script>


### PR DESCRIPTION
## Summary
- load Conversations SDK variant that exposes the Twilio global in webchat sample

## Testing
- `npm test` *(fails: Missing script "test")*
- `curl -I https://media.twiliocdn.com/sdk/js/conversations/v2.4/twilio-conversations.min.js` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a872452ce8832abf1e4d5b0d9e6133