### PR TITLE
Validate Twilio SDK presence in webchat sample

### DIFF
--- a/samples/webchat/chat.js
+++ b/samples/webchat/chat.js
@@ -53,6 +53,10 @@ const API_BASE = window.API_BASE || 'http://localhost:4000';
     }
 
     // Initialize Conversations client and join
+    if (!window.Twilio?.Conversations?.Client) {
+      alert('Twilio Conversations SDK failed to load.');
+      return;
+    }
     const client = await Twilio.Conversations.Client.create(token);
     conversation = await client.getConversationBySid(convoData.sid);
     await conversation.join();

--- a/samples/webchat/index.html
+++ b/samples/webchat/index.html
@@ -21,10 +21,11 @@
     </form>
   </div>
 
+  <!-- Load the Twilio Conversations SDK before our chat logic -->
   <script src="https://media.twiliocdn.com/sdk/js/conversations/v2.4/twilio-conversations.min.js"></script>
   <script>
     window.API_BASE = 'http://localhost:4000'; // adjust as needed
   </script>
-  <script src="chat.js"></script>
+  <script src="chat.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Ensure Twilio Conversations SDK script loads before webchat logic.
- Guard chat initialization when Twilio SDK isn't available.

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a87330a450832aaf0df52bafa04d12