### PR TITLE
Scope conversation API calls to service context

### DIFF
--- a/apps/server/src/conversations/service.js
+++ b/apps/server/src/conversations/service.js
@@ -2,11 +2,14 @@ import { twilioClient as client } from './client.js';
 
 
 const {
-TWILIO_MESSAGING_SERVICE_SID, // optional MGxxxxxxxx for SMS/WhatsApp
-TWILIO_SMS_NUMBER, // optional +E.164
-TWILIO_WHATSAPP_NUMBER, // optional +E.164 (without whatsapp: prefix)
-TWILIO_MESSENGER_PAGE_ID, // optional FB Page ID for Messenger
+  TWILIO_MESSAGING_SERVICE_SID, // optional MGxxxxxxxx for SMS/WhatsApp
+  TWILIO_SMS_NUMBER, // optional +E.164
+  TWILIO_WHATSAPP_NUMBER, // optional +E.164 (without whatsapp: prefix)
+  TWILIO_MESSENGER_PAGE_ID, // optional FB Page ID for Messenger
+  TWILIO_CONVERSATIONS_SERVICE_SID, // required ISxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 } = process.env;
+
+const service = client.conversations.v1.services(TWILIO_CONVERSATIONS_SERVICE_SID);
 
 
 /**
@@ -16,16 +19,16 @@ export async function getOrCreateConversation({ uniqueName, friendlyName, attrib
   if (!uniqueName) throw new Error('uniqueName required');
   try {
     // Twilio REST allows SID or uniqueName in the path for fetch — we attempt fetch first.
-    return await client.conversations.v1.conversations(uniqueName).fetch();
+    return await service.conversations(uniqueName).fetch();
   } catch (err) {
     if (err.status !== 404) throw err;
-    const convo = await client.conversations.v1.conversations.create({
+    const convo = await service.conversations.create({
       uniqueName,
       friendlyName: friendlyName || uniqueName,
       attributes: JSON.stringify({ ...attributes, taskSid: null }),
       messagingServiceSid: TWILIO_MESSAGING_SERVICE_SID || undefined,
     });
-    return client.conversations.v1.conversations(convo.sid).update({
+    return service.conversations(convo.sid).update({
       'timers.inactive': 'PT15M',
       'timers.closed': 'P1D'
     });
@@ -36,7 +39,7 @@ export async function getOrCreateConversation({ uniqueName, friendlyName, attrib
 /** Add a WebChat participant via Conversations SDK identity */
 export function addChatParticipant(conversationSid, { identity, attributes } = {}) {
 if (!identity) throw new Error('identity required');
-return client.conversations.v1.conversations(conversationSid).participants.create({
+return service.conversations(conversationSid).participants.create({
 identity,
 attributes: attributes ? JSON.stringify(attributes) : undefined,
 });
@@ -47,7 +50,7 @@ attributes: attributes ? JSON.stringify(attributes) : undefined,
 export function addSmsParticipant(conversationSid, { to, from }) {
 const proxy = from || TWILIO_SMS_NUMBER;
 if (!to || !proxy) throw new Error('to and from (or TWILIO_SMS_NUMBER) are required');
-return client.conversations.v1.conversations(conversationSid).participants.create({
+return service.conversations(conversationSid).participants.create({
 'messagingBinding.address': to, // e.g. +15551234567
 'messagingBinding.proxyAddress': proxy, // your Twilio SMS number
 });
@@ -58,7 +61,7 @@ return client.conversations.v1.conversations(conversationSid).participants.creat
 export function addWhatsappParticipant(conversationSid, { to, from }) {
 const proxy = from || TWILIO_WHATSAPP_NUMBER;
 if (!to || !proxy) throw new Error('to and from (or TWILIO_WHATSAPP_NUMBER) are required');
-return client.conversations.v1.conversations(conversationSid).participants.create({
+return service.conversations(conversationSid).participants.create({
 'messagingBinding.address': `whatsapp:${to}`,
 'messagingBinding.proxyAddress': `whatsapp:${proxy}`,
 });
@@ -69,7 +72,7 @@ return client.conversations.v1.conversations(conversationSid).participants.creat
 export function addMessengerParticipant(conversationSid, { userId, pageId }) {
 const proxy = pageId || TWILIO_MESSENGER_PAGE_ID;
 if (!userId || !proxy) throw new Error('userId and pageId (or TWILIO_MESSENGER_PAGE_ID) are required');
-return client.conversations.v1.conversations(conversationSid).participants.create({
+return service.conversations(conversationSid).participants.create({
 'messagingBinding.address': `messenger:${userId}`,
 'messagingBinding.proxyAddress': `messenger:${proxy}`,
 });
@@ -91,7 +94,7 @@ export function sendMessage(
   if (body) payload.body = body;
   if (mediaSid) payload.mediaSid = mediaSid;
   if (attributes) payload.attributes = JSON.stringify(attributes);
-  return client.conversations.v1
+  return service
     .conversations(conversationSid)
     .messages.create(payload, { xTwilioWebhookEnabled: true });
 }
@@ -107,17 +110,17 @@ cfg['configuration.filters'] = filters;
 } else if (target === 'studio') {
 cfg['configuration.flowSid'] = flowSid;
 }
-return client.conversations.v1.conversations(conversationSid).webhooks.create({ target, ...cfg });
+return service.conversations(conversationSid).webhooks.create({ target, ...cfg });
 }
 
 export const fetchConversation = (sid) =>
-  client.conversations.v1.conversations(sid).fetch();
+  service.conversations(sid).fetch();
 
 export async function updateConversationAttributes(conversationSid, newAttributes = {}) {
   const convo = await fetchConversation(conversationSid);
   const current = convo.attributes ? JSON.parse(convo.attributes) : {};
   const merged = { ...current, ...newAttributes };
-  return client.conversations.v1.conversations(conversationSid).update({
+  return service.conversations(conversationSid).update({
     attributes: JSON.stringify(merged)
   });
 }
@@ -126,7 +129,7 @@ export function listMessageReceipts(conversationSid, messageSid) {
   if (!conversationSid || !messageSid) {
     throw new Error('conversationSid and messageSid are required');
   }
-  return client.conversations.v1
+  return service
     .conversations(conversationSid)
     .messages(messageSid)
     .deliveryReceipts.list();
@@ -136,5 +139,5 @@ export function updateConversationTimers(conversationSid, { inactive, closed } =
   const payload = {};
   if (inactive) payload['timers.inactive'] = inactive;
   if (closed) payload['timers.closed'] = closed;
-  return client.conversations.v1.conversations(conversationSid).update(payload);
+  return service.conversations(conversationSid).update(payload);
 }


### PR DESCRIPTION
## Summary
- Scope conversation fetch/create to Twilio Conversations Service
- Route all conversation operations through the service-scoped API

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a876031dc8832ab89c927c2fe0a66b