### PR TITLE
Guard conversation join in webchat sample

### DIFF
--- a/samples/webchat/chat.js
+++ b/samples/webchat/chat.js
@@ -35,22 +35,7 @@ const API_BASE = window.API_BASE || 'http://localhost:4000';
       alert('Failed to fetch token');
       return;
     }
-    const { token, identity } = await tokenRes.json();
-
-    // Add this user as chat participant
-    const participantRes = await fetch(`${API_BASE}/api/conversations/${convoData.sid}/participants`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        type: 'chat',
-        identity,
-        attributes: { name, email }
-      })
-    });
-    if (!participantRes.ok) {
-      alert('Failed to add participant to conversation');
-      return;
-    }
+    const { token } = await tokenRes.json();
 
     // Initialize Conversations client and join
     if (!window.Twilio?.Conversations?.Client) {
@@ -64,7 +49,9 @@ const API_BASE = window.API_BASE || 'http://localhost:4000';
       );
     }
     conversation = await client.getConversationBySid(convoData.sid);
-    await conversation.join();
+    if (conversation.state !== 'joined') {
+      await conversation.join();
+    }
 
     startForm.style.display = 'none';
     chatContainer.style.display = 'block';


### PR DESCRIPTION
## Summary
- Remove REST-based participant creation and rely on `conversation.join()` to create the participant
- Skip `conversation.join()` when already joined

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a8838c0fe0832aa91e4fadb3d61d6c