### PR TITLE
feat: add shared softphone layout

### DIFF
--- a/apps/client/src/features/softphone/components/Softphone.jsx
+++ b/apps/client/src/features/softphone/components/Softphone.jsx
@@ -5,6 +5,7 @@ import DialPad from './DialPad.jsx';
 import IncomingModal from './IncomingModal.jsx';
 import DtmfModal from './DtmfModal.jsx';
 import CallControlBar from './CallControlBar.jsx';
+import SoftphoneLayout from './SoftphoneLayout.jsx';
 
 import { Box } from '@twilio-paste/core/box';
 import { Stack } from '@twilio-paste/core/stack';
@@ -51,107 +52,96 @@ export default function Softphone({ remoteOnly, popupOpen = false }) {
   if (!remoteOnly && popupOpen) return null;
   if (!ready) return <SkeletonLoader />;
 
-  return (
-    <Box
-      backgroundColor="colorBackground"
-      borderRadius="borderRadius30"
-      boxShadow="shadow"
-      padding="space70"
-      display="flex"
-      flexDirection="column"
-      height="100%"
-      minHeight="0"
-    >
-
-      {error ? (
-        <Box marginBottom="space50">
-          <Alert variant="error">{error}</Alert>
-        </Box>
-      ) : null}
-
-      <Stack
-        orientation={['vertical', 'horizontal']}
-        spacing="space50"
-        distribution="spaceBetween"
-        alignment="center"
-        style={{ flexWrap: 'wrap' }}
-      >
-        <Heading as="h3" variant="heading30" margin="space0">
-          {t('softphone')}
-        </Heading>
-
-        <Stack orientation="horizontal" spacing="space50" style={{ flexWrap: 'wrap' }}>
-          <Box>
-            <Badge as="span" variant="success">{t('registered')}</Badge>
+  const layout = (
+    <>
+      <Box className={styles.header}>
+        {error ? (
+          <Box marginBottom="space50">
+            <Alert variant="error">{error}</Alert>
           </Box>
-          <Separator orientation="vertical" />
-          <Box>
-            <Badge
-              as="span"
-              variant={callStatus === 'In Call' ? 'new' : callStatus === 'Incoming' ? 'warning' : 'neutral'}
-            >
-              {t('call')}: {callStatus}
-            </Badge>
-          </Box>
-          {callStatus === 'In Call' ? <Box className={styles.pill}>⏱ {elapsed}</Box> : null}
-        </Stack>
-      </Stack>
+        ) : null}
 
-      <Separator orientation="horizontal" verticalSpacing="space50" />
-
-      <Box className={styles.body}>
-        <Box display="flex" flexDirection="column" gap="space60" minHeight="0">
-          <Stack orientation={['vertical', 'horizontal']} spacing="space50" style={{ flexWrap: 'wrap' }}>
-            <Input
-              placeholder={t('dialPlaceholder')}
-              value={to}
-              onChange={(e) => setTo(e.target.value)}
-              size="default"
-            />
-            <Button
-              variant="primary"
-              onClick={() => dial()}
-              disabled={!to.trim() || callStatus === 'In Call'}
-              aria-label={t('callAria')}
-              title={t('callAria')}
-            >
-              {t('call')}
-            </Button>
-          </Stack>
-
-          <CallControlBar
-            callStatus={callStatus}
-            isMuted={isMuted}
-            holding={holding}
-            recStatus={recStatus}
-            hangup={hangup}
-            toggleMute={toggleMute}
-            holdStart={holdStart}
-            holdStop={holdStop}
-            recStart={recStart}
-            recPause={recPause}
-            recResume={recResume}
-            recStop={recStop}
-            onOpenDtmf={() => setIsDtmfOpen(true)}
-          />
-
-          <HelpText variant="default">{isMuted ? t('micMuted') : t('micLive')}</HelpText>
-          <HelpText variant="default">
-            {t('hold')}: {holding ? t('yes') : t('no')}
-          </HelpText>
-          <HelpText variant="default">
-            {t('recording')}: {recStatus}
-          </HelpText>
-        </Box>
-
-        <Box>
-          <Heading as="h4" variant="heading40" marginBottom="space50">
-            {t('dtmfKeypad')}
+        <Stack
+          orientation={['vertical', 'horizontal']}
+          spacing="space50"
+          distribution="spaceBetween"
+          alignment="center"
+          style={{ flexWrap: 'wrap' }}
+        >
+          <Heading as="h3" variant="heading30" margin="space0">
+            {t('softphone')}
           </Heading>
-          <DialPad onDigit={sendDtmf} disabled={callStatus !== 'In Call'} />
-        </Box>
+
+          <Stack orientation="horizontal" spacing="space50" style={{ flexWrap: 'wrap' }}>
+            <Box>
+              <Badge as="span" variant="success">{t('registered')}</Badge>
+            </Box>
+            <Separator orientation="vertical" />
+            <Box>
+              <Badge
+                as="span"
+                variant={callStatus === 'In Call' ? 'new' : callStatus === 'Incoming' ? 'warning' : 'neutral'}
+              >
+                {t('call')}: {callStatus}
+              </Badge>
+            </Box>
+            {callStatus === 'In Call' ? <Box className={styles.pill}>⏱ {elapsed}</Box> : null}
+          </Stack>
+        </Stack>
+
+        <Separator orientation="horizontal" verticalSpacing="space50" />
       </Box>
 
+      <Box className={styles.controls}>
+        <Stack orientation={['vertical', 'horizontal']} spacing="space50" style={{ flexWrap: 'wrap' }}>
+          <Input
+            placeholder={t('dialPlaceholder')}
+            value={to}
+            onChange={(e) => setTo(e.target.value)}
+            size="default"
+          />
+          <Button
+            variant="primary"
+            onClick={() => dial()}
+            disabled={!to.trim() || callStatus === 'In Call'}
+            aria-label={t('callAria')}
+            title={t('callAria')}
+          >
+            {t('call')}
+          </Button>
+        </Stack>
+
+        <CallControlBar
+          callStatus={callStatus}
+          isMuted={isMuted}
+          holding={holding}
+          recStatus={recStatus}
+          hangup={hangup}
+          toggleMute={toggleMute}
+          holdStart={holdStart}
+          holdStop={holdStop}
+          recStart={recStart}
+          recPause={recPause}
+          recResume={recResume}
+          recStop={recStop}
+          onOpenDtmf={() => setIsDtmfOpen(true)}
+        />
+
+        <HelpText variant="default">{isMuted ? t('micMuted') : t('micLive')}</HelpText>
+        <HelpText variant="default">
+          {t('hold')}: {holding ? t('yes') : t('no')}
+        </HelpText>
+        <HelpText variant="default">
+          {t('recording')}: {recStatus}
+        </HelpText>
+      </Box>
+
+      <Box className={styles.dialpad}>
+        <Heading as="h4" variant="heading40" marginBottom="space50">
+          {t('dtmfKeypad')}
+        </Heading>
+        <DialPad onDigit={sendDtmf} disabled={callStatus !== 'In Call'} />
+      </Box>
       <IncomingModal
         isOpen={isIncomingOpen}
         onAccept={acceptIncoming}
@@ -165,6 +155,8 @@ export default function Softphone({ remoteOnly, popupOpen = false }) {
         onDigit={sendDtmf}
         disabled={callStatus !== 'In Call'}
       />
-    </Box>
+    </>
   );
+
+  return remoteOnly ? layout : <SoftphoneLayout>{layout}</SoftphoneLayout>;
 }

--- a/apps/client/src/features/softphone/components/Softphone.module.css
+++ b/apps/client/src/features/softphone/components/Softphone.module.css
@@ -1,24 +1,60 @@
-.body {
-  flex: 1;
-  min-height: 0;
+.layout {
   display: grid;
   gap: var(--paste-space-70);
+  grid-template-areas:
+    'header'
+    'controls'
+    'dialpad';
+  height: 100%;
+  min-height: 0;
 }
+
+.header {
+  grid-area: header;
+}
+
+.controls {
+  grid-area: controls;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--paste-space-60);
+}
+
+.dialpad {
+  grid-area: dialpad;
+}
+
 @media (min-width: 768px) {
-  .body { grid-template-columns: 1fr 1fr; }
+  .layout {
+    grid-template-columns: 1fr 1fr;
+    grid-template-areas:
+      'header header'
+      'controls dialpad';
+  }
 }
+
 @media (max-width: 767px) {
-  .body { grid-template-columns: 1fr; }
+  .layout {
+    grid-template-columns: 1fr;
+    grid-template-areas:
+      'header'
+      'controls'
+      'dialpad';
+  }
 }
+
 .key {
   width: 100%;
   height: 48px;
 }
+
 .padGrid {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   gap: var(--paste-space-40);
 }
+
 .pill {
   border-radius: 9999px;
   padding: 2px 10px;

--- a/apps/client/src/features/softphone/components/SoftphoneLayout.jsx
+++ b/apps/client/src/features/softphone/components/SoftphoneLayout.jsx
@@ -1,0 +1,17 @@
+import { Box } from '@twilio-paste/core/box';
+import styles from './Softphone.module.css';
+
+export default function SoftphoneLayout({ children }) {
+  return (
+    <Box
+      backgroundColor="colorBackground"
+      borderRadius="borderRadius30"
+      boxShadow="shadow"
+      padding="space70"
+      className={styles.layout}
+      minHeight="100vh"
+    >
+      {children}
+    </Box>
+  );
+}

--- a/apps/client/src/main.jsx
+++ b/apps/client/src/main.jsx
@@ -3,6 +3,7 @@ import { createRoot } from 'react-dom/client';
 import { Theme } from '@twilio-paste/core/theme';
 import App from './App.jsx';
 import Softphone from './features/softphone/components/Softphone.jsx';
+import SoftphoneLayout from './features/softphone/components/SoftphoneLayout.jsx';
 
 const root = createRoot(document.getElementById('root'));
 
@@ -13,9 +14,9 @@ root.render(
   <Theme.Provider theme="default">
     {remoteOnly ? (
       // Popup renders the Softphone in remoteOnly mode
-      <div style={{ minHeight: '100vh', background: 'var(--paste-color-background-body)', padding: '16px' }}>
+      <SoftphoneLayout>
         <Softphone remoteOnly={remoteOnly} />
-      </div>
+      </SoftphoneLayout>
     ) : (
       <App />
     )}


### PR DESCRIPTION
## Summary
- add SoftphoneLayout component with grid template areas
- integrate layout in Softphone component and popup entry
- update styles for header, controls, and dialpad with responsive breakpoints

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Rollup failed to resolve import `@twilio-paste/core/icon-button`)*

------
https://chatgpt.com/codex/tasks/task_e_68a88c2d8758832a8adc9d663556ef3a