### PR TITLE
refactor: centralize call controls hook

### DIFF
--- a/apps/client/src/features/softphone/components/CallControlsModal.jsx
+++ b/apps/client/src/features/softphone/components/CallControlsModal.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Box } from '@twilio-paste/core/box';
 import { Stack } from '@twilio-paste/core/stack';
@@ -14,54 +14,30 @@ import {
 } from '@twilio-paste/core/modal';
 import Api from '../../index.js';
 import { getCallSid } from '../services/callSidStore.js';
-import {
-  SOFTPHONE_CHANNEL_KEY,
-  SOFTPHONE_POPUP_FEATURES,
-} from '../constants.js';
+import { SOFTPHONE_POPUP_FEATURES } from '../constants.js';
+import CallControlBar from './CallControlBar.jsx';
+import useCallControls from './useCallControls.js';
 
 export default function CallControlsModal({ isOpen, onDismiss }) {
   const { t } = useTranslation();
   const [agentCallSid, setAgentCallSid] = useState(null);
-  const [task, setTask] = useState(null);             // Task activa (para customerCallSid / taskSid)
   const [customerCallSid, setCustomerCallSid] = useState(null);
-  const [recStatus, setRecStatus] = useState('inactive'); // 'inactive' | 'in-progress' | 'paused' | 'stopped'
-  const [muted, setMuted] = useState(false);
-  const [holding, setHolding] = useState(false);
-  const chanRef = useRef(null);
 
-  const canHold = useMemo(
-    () => Boolean(agentCallSid && customerCallSid),
-    [agentCallSid, customerCallSid]
-  );
+  const {
+    callStatus,
+    isMuted,
+    holding,
+    recStatus,
+    hangup,
+    toggleMute,
+    holdStart,
+    holdStop,
+    recStart,
+    recPause,
+    recResume,
+    recStop,
+  } = useCallControls();
 
-  // --- escuchar estado del Softphone (mute) via BroadcastChannel
-  useEffect(() => {
-    const ch = new BroadcastChannel(SOFTPHONE_CHANNEL_KEY);
-    chanRef.current = ch;
-
-    ch.onmessage = (evt) => {
-      const msg = evt?.data || {};
-      if (msg.type === 'state') {
-        setMuted(!!msg.payload?.isMuted);
-      }
-    };
-    // pedir estado inicial
-    try {
-      ch.postMessage({ type: 'cmd', payload: { action: 'ping' } });
-    } catch (err) {
-      console.error('softphone channel ping error', err);
-    }
-
-    return () => {
-      try {
-        ch.close();
-      } catch (err) {
-        console.error('softphone channel close error', err);
-      }
-    };
-  }, [isOpen]);
-
-  // --- al abrir: obtener callSid agente + task activa + status de recording
   useEffect(() => {
     if (!isOpen) return;
     const sid = getCallSid();
@@ -70,81 +46,18 @@ export default function CallControlsModal({ isOpen, onDismiss }) {
     (async () => {
       try {
         const list = await Api.myTasks('assigned,reserved,wrapping');
-        // Elegimos la que tenga callSid (customer) disponible primero
         const picked =
           list.find((t) => t?.attributes?.callSid || t?.attributes?.call_sid) ||
           list[0] ||
           null;
-        setTask(picked || null);
         setCustomerCallSid(
           picked?.attributes?.callSid || picked?.attributes?.call_sid || null,
         );
       } catch (err) {
         console.error(err);
       }
-
-      if (sid) {
-        try {
-          const s = await Api.recStatus(sid);
-          setRecStatus(s || 'inactive');
-        } catch (err) {
-          console.error(err);
-          setRecStatus('inactive');
-        }
-      }
     })();
   }, [isOpen]);
-
-  // --- poll recording status mientras esté abierto y haya llamada
-  useEffect(() => {
-    if (!isOpen || !agentCallSid) return;
-    const iv = setInterval(async () => {
-      try {
-        const s = await Api.recStatus(agentCallSid);
-        setRecStatus(s || 'inactive');
-      } catch (err) {
-        console.error(err);
-      }
-    }, 3000);
-    return () => clearInterval(iv);
-  }, [isOpen, agentCallSid]);
-
-  // --- helpers de comandos al Softphone (mute/hangup)
-  const sendCmd = (action) => {
-    try {
-      chanRef.current?.postMessage({ type: 'cmd', payload: { action } });
-    } catch (err) {
-      console.error(err);
-    }
-  };
-
-  // --- Recording controls
-  const startRec  = async () => { if (agentCallSid) { await Api.recStart(agentCallSid); setRecStatus('in-progress'); } };
-  const pauseRec  = async () => { if (agentCallSid) { await Api.recPause(agentCallSid); setRecStatus('paused'); } };
-  const resumeRec = async () => { if (agentCallSid) { await Api.recResume(agentCallSid); setRecStatus('in-progress'); } };
-  const stopRec   = async () => { if (agentCallSid) { await Api.recStop(agentCallSid);  setRecStatus('stopped'); } };
-
-  // --- Hold controls (cliente)
-  const hold = async () => {
-    if (!canHold) return;
-    await Api.holdStart({
-      taskSid: task?.sid,
-      customerCallSid,
-      agentCallSid,
-      who: 'customer'
-    });
-    setHolding(true);
-  };
-  const unhold = async () => {
-    if (!canHold) return;
-    await Api.holdStop({
-      taskSid: task?.sid,
-      customerCallSid,
-      agentCallSid,
-      who: 'customer'
-    });
-    setHolding(false);
-  };
 
   const openSoftphonePopout = () => {
     window.open(
@@ -198,68 +111,24 @@ export default function CallControlsModal({ isOpen, onDismiss }) {
 
           <Separator orientation="horizontal" />
 
-          {/* Recording */}
-          <Stack
-            orientation={['vertical', 'horizontal']}
-            spacing="space40"
-            style={{ flexWrap: 'wrap' }}
-          >
-            <Button
-              variant="secondary"
-              onClick={startRec}
-              disabled={!agentCallSid || (recStatus !== 'inactive' && recStatus !== 'stopped')}
-            >
-              {t('startRecTitle')}
-            </Button>
-            <Button
-              variant="secondary"
-              onClick={pauseRec}
-              disabled={recStatus !== 'in-progress'}
-            >
-              {t('pauseRecTitle')}
-            </Button>
-            <Button
-              variant="secondary"
-              onClick={resumeRec}
-              disabled={recStatus !== 'paused'}
-            >
-              {t('resumeRecTitle')}
-            </Button>
-            <Button
-              variant="secondary"
-              onClick={stopRec}
-              disabled={recStatus === 'inactive'}
-            >
-              {t('stopRecTitle')}
-            </Button>
-          </Stack>
-
-          {/* Call actions */}
-          <Stack orientation={['vertical','horizontal']} spacing="space40" style={{ flexWrap: 'wrap' }}>
-            <Button variant="secondary" onClick={holding ? unhold : hold} disabled={!canHold}>
-              {holding ? t('resume') : t('hold')}
-            </Button>
-            <Button
-              variant="secondary"
-              onClick={() => {
-                sendCmd(muted ? 'unmute' : 'mute');
-                setMuted(!muted);
-              }}
-              disabled={!agentCallSid}
-            >
-              {muted ? t('unmute') : t('mute')}
-            </Button>
-            <Button
-              variant="destructive"
-              onClick={() => {
-                sendCmd('hangup');
-                onDismiss?.();
-              }}
-              disabled={!agentCallSid}
-            >
-              {t('hangup')}
-            </Button>
-          </Stack>
+          <CallControlBar
+            callStatus={callStatus}
+            isMuted={isMuted}
+            holding={holding}
+            recStatus={recStatus}
+            hangup={() => {
+              hangup();
+              onDismiss?.();
+            }}
+            toggleMute={toggleMute}
+            holdStart={holdStart}
+            holdStop={holdStop}
+            recStart={recStart}
+            recPause={recPause}
+            recResume={recResume}
+            recStop={recStop}
+            onOpenDtmf={() => {}}
+          />
 
           <Separator orientation="horizontal" />
 

--- a/apps/client/src/features/softphone/components/Softphone.jsx
+++ b/apps/client/src/features/softphone/components/Softphone.jsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import useSoftphone from '../hooks/useSoftphone.js';
+import useCallControls from './useCallControls.js';
 import DialPad from './DialPad.jsx';
 import IncomingModal from './IncomingModal.jsx';
 import DtmfModal from './DtmfModal.jsx';
@@ -21,19 +22,26 @@ import styles from './Softphone.module.css';
 
 export default function Softphone({ remoteOnly, popupOpen = false }) {
   const { t } = useTranslation();
+  const softphone = useSoftphone(remoteOnly);
   const {
     ready,
     to,
     setTo,
     isIncomingOpen,
     setIncomingOpen,
+    elapsed,
+    error,
+    dial,
+    acceptIncoming,
+    rejectIncoming,
+    sendDtmf,
+  } = softphone;
+
+  const {
     callStatus,
     isMuted,
     holding,
     recStatus,
-    elapsed,
-    error,
-    dial,
     hangup,
     toggleMute,
     holdStart,
@@ -42,10 +50,7 @@ export default function Softphone({ remoteOnly, popupOpen = false }) {
     recPause,
     recResume,
     recStop,
-    acceptIncoming,
-    rejectIncoming,
-    sendDtmf,
-  } = useSoftphone(remoteOnly);
+  } = useCallControls(softphone);
 
   const [isDtmfOpen, setIsDtmfOpen] = useState(false);
 

--- a/apps/client/src/features/softphone/components/useCallControls.js
+++ b/apps/client/src/features/softphone/components/useCallControls.js
@@ -1,0 +1,35 @@
+import useSoftphone from '../hooks/useSoftphone.js';
+
+export default function useCallControls(softphone) {
+  const sp = softphone || useSoftphone(true);
+
+  const {
+    callStatus,
+    isMuted,
+    holding,
+    recStatus,
+    hangup,
+    toggleMute,
+    holdStart,
+    holdStop,
+    recStart,
+    recPause,
+    recResume,
+    recStop,
+  } = sp;
+
+  return {
+    callStatus,
+    isMuted,
+    holding,
+    recStatus,
+    hangup,
+    toggleMute,
+    holdStart,
+    holdStop,
+    recStart,
+    recPause,
+    recResume,
+    recStop,
+  };
+}


### PR DESCRIPTION
## Summary
- extract `useCallControls` hook for mute, hold and recording actions
- use shared hook in `Softphone` and `CallControlsModal`
- replace modal button stack with `CallControlBar` for consistent UI

## Testing
- `npm test` *(fails: Missing script "test")*
- `(apps/client) npm test` *(fails: Missing script "test" in workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68a8919c5ae0832abe87069dd6a845b3