### PR TITLE
Attach Studio Flow to new Conversations

### DIFF
--- a/samples/webchat/chat.js
+++ b/samples/webchat/chat.js
@@ -1,4 +1,5 @@
 const API_BASE = window.API_BASE || 'http://localhost:4000';
+const STUDIO_FLOW_SID = '<YOUR_STUDIO_FLOW_SID>';
 
 (async function () {
   const startForm = document.getElementById('start-form');
@@ -28,6 +29,20 @@ const API_BASE = window.API_BASE || 'http://localhost:4000';
       return;
     }
     const convoData = await convoRes.json();
+
+    // Attach Studio Flow webhook to this conversation
+    const webhookRes = await fetch(
+      `${API_BASE}/api/conversations/${convoData.sid}/webhooks`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ target: 'studio', flowSid: STUDIO_FLOW_SID }),
+      }
+    );
+    if (!webhookRes.ok) {
+      alert('Failed to attach Studio Flow');
+      return;
+    }
 
     // Fetch token for Conversations SDK
     const tokenRes = await fetch(`${API_BASE}/api/chat/token`);


### PR DESCRIPTION
## Summary
- enable webchat sample to attach a Studio Flow webhook after conversation creation

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a8937657c8832abcab42a0cd6309e7