### PR TITLE
fix: update IconButton import path

### DIFF
--- a/apps/client/src/features/softphone/components/CallControlBar.jsx
+++ b/apps/client/src/features/softphone/components/CallControlBar.jsx
@@ -1,6 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import { ButtonGroup } from '@twilio-paste/core/button-group';
-import { IconButton } from '@twilio-paste/core/icon-button';
+import { IconButton } from '@twilio-paste/core/button';
 import { Tooltip } from '@twilio-paste/core/tooltip';
 import { Menu, MenuButton, MenuItem, useMenuState } from '@twilio-paste/core/menu';
 import { HangupIcon } from '@twilio-paste/icons/esm/HangupIcon';


### PR DESCRIPTION
## Summary
- update IconButton import to use `@twilio-paste/core/button`

## Testing
- `npm --prefix apps/client run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8bf2071f0832aafa73b40a2a8a9ab