### PR TITLE
Add Conversations pre-event webhook for message moderation

### DIFF
--- a/apps/server/src/conversations/service.js
+++ b/apps/server/src/conversations/service.js
@@ -164,3 +164,13 @@ export function updateConversationTimers(conversationSid, { inactive, closed } =
   if (closed) payload['timers.closed'] = closed;
   return service.conversations(conversationSid).update(payload);
 }
+
+export function configureServiceWebhooks({ preWebhookUrl } = {}) {
+  const payload = {};
+  if (preWebhookUrl) {
+    payload.preWebhookUrl = preWebhookUrl;
+    payload.preWebhookMethod = 'POST';
+  }
+  if (Object.keys(payload).length === 0) return Promise.resolve();
+  return service.update(payload);
+}

--- a/apps/server/src/index.js
+++ b/apps/server/src/index.js
@@ -17,6 +17,8 @@ import { crmProxy } from './routes/crm.js';
 import chatTokenRoute from './routes/chat-token.route.js';
 import conversationsRoute from './routes/conversations.route.js';
 import conversationsWebhooksRoute from './routes/conversations-webhooks.route.js';
+import conversationsPreWebhooksRoute from './routes/conversations-prewebhooks.route.js';
+import { configureServiceWebhooks } from './conversations/service.js';
 
 const app = express();
 validateEnv();
@@ -61,7 +63,14 @@ app.use('/api', ivr);
 app.use('/api', crmProxy);
 app.use('/api/chat', chatTokenRoute);
 app.use('/api/conversations', conversationsRoute);
+app.use('/webhooks/conversations/pre', conversationsPreWebhooksRoute);
 app.use('/webhooks/conversations', conversationsWebhooksRoute);
+
+if (env.publicBaseUrl) {
+  configureServiceWebhooks({
+    preWebhookUrl: `${env.publicBaseUrl}/webhooks/conversations/pre`
+  }).catch(e => console.error('Failed to configure Conversations pre-webhook', e));
+}
 // --- HTTP + Socket.IO con CORS ---
 const server = http.createServer(app);
 const io = new Server(server, {

--- a/apps/server/src/routes/conversations-prewebhooks.route.js
+++ b/apps/server/src/routes/conversations-prewebhooks.route.js
@@ -1,0 +1,40 @@
+import express from 'express';
+
+const router = express.Router();
+
+// Simple content moderation placeholder. In a real implementation
+// you might call an external service or a more sophisticated model.
+const MAX_MESSAGE_LENGTH = 1600;
+const bannedWords = ['banned', 'profanity'];
+
+function failsModeration(body = '') {
+  const lower = body.toLowerCase();
+  return bannedWords.some(w => lower.includes(w));
+}
+
+router.post('/', (req, res) => {
+  const eventType = req.body.EventType || req.body.EventType?.toString();
+  console.log('[Conversations PreWebhook]', eventType, req.body?.MessageSid || '');
+
+  try {
+    if (eventType === 'onMessageAdd') {
+      const body = req.body.Body || '';
+
+      if (body.length > MAX_MESSAGE_LENGTH) {
+        return res.status(413).send('Message too long');
+      }
+
+      if (failsModeration(body)) {
+        return res.status(422).send('Message failed moderation');
+      }
+    }
+
+    res.status(200).send('ok');
+  } catch (e) {
+    console.error('[Conversations PreWebhook] error:', e);
+    res.status(500).send('error');
+  }
+});
+
+export default router;
+


### PR DESCRIPTION
## Summary
- add Conversations pre-webhook route to validate onMessageAdd events
- configure service pre-webhook and register new route

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a90d0b06d8832aaa75d1cf082d7d62