### PR TITLE
Handle participant lifecycle in conversation webhooks

### DIFF
--- a/apps/server/src/routes/conversations-webhooks.route.js
+++ b/apps/server/src/routes/conversations-webhooks.route.js
@@ -1,5 +1,11 @@
 import express from 'express';
-import { createTask, completeTask, pushEvent } from '../services/taskrouter.js';
+import {
+  createTask,
+  completeTask,
+  fetchTask,
+  pushEvent,
+  updateTask
+} from '../services/taskrouter.js';
 import { fetchConversation, updateConversationAttributes } from '../conversations/service.js';
 
 const router = express.Router();
@@ -40,6 +46,101 @@ router.post('/', async (req, res) => {
           });
           pushEvent('TASK_CREATED', { taskSid: task.sid, conversationSid });
           io?.emit('task_created', { taskSid: task.sid, conversationSid });
+        }
+      }
+    } else if (eventType === 'onParticipantAdded') {
+      const conversationSid = req.body.ConversationSid;
+      const participantSid = req.body.ParticipantSid;
+      const identity = req.body.Identity;
+      let participantAttrs = {};
+      try {
+        participantAttrs = req.body.ParticipantAttributes
+          ? JSON.parse(req.body.ParticipantAttributes)
+          : {};
+      } catch {
+        participantAttrs = {};
+      }
+      const convo = await fetchConversation(conversationSid);
+      const attrs = convo.attributes ? JSON.parse(convo.attributes) : {};
+      const participants = attrs.participants || {};
+      participants[participantSid] = { identity, role: participantAttrs.role };
+      const updates = { participants };
+      const now = new Date().toISOString();
+      if (participantAttrs.role === 'agent' && !attrs.agentJoinedAt) {
+        updates.agentJoinedAt = now;
+        if (attrs.taskSid) {
+          try {
+            const task = await fetchTask(attrs.taskSid);
+            const tAttrs = task.attributes ? JSON.parse(task.attributes) : {};
+            await updateTask(attrs.taskSid, {
+              attributes: JSON.stringify({ ...tAttrs, agentJoinedAt: now })
+            });
+            pushEvent('TASK_UPDATED', {
+              taskSid: attrs.taskSid,
+              conversationSid
+            });
+            io?.emit('task_updated', {
+              taskSid: attrs.taskSid,
+              conversationSid
+            });
+          } catch (err) {
+            console.error('task update error', err);
+          }
+        }
+      }
+      await updateConversationAttributes(conversationSid, updates);
+      const payload = {
+        conversationSid,
+        participantSid,
+        identity,
+        role: participantAttrs.role
+      };
+      pushEvent('PARTICIPANT_ADDED', payload);
+      io?.emit('participant_added', payload);
+    } else if (eventType === 'onParticipantRemoved') {
+      const conversationSid = req.body.ConversationSid;
+      const participantSid = req.body.ParticipantSid;
+      let participantAttrs = {};
+      try {
+        participantAttrs = req.body.ParticipantAttributes
+          ? JSON.parse(req.body.ParticipantAttributes)
+          : {};
+      } catch {
+        participantAttrs = {};
+      }
+      const convo = await fetchConversation(conversationSid);
+      const attrs = convo.attributes ? JSON.parse(convo.attributes) : {};
+      const participants = attrs.participants || {};
+      const removed = participants[participantSid];
+      delete participants[participantSid];
+      await updateConversationAttributes(conversationSid, { participants });
+      const payload = {
+        conversationSid,
+        participantSid,
+        identity: removed?.identity,
+        role: removed?.role
+      };
+      pushEvent('PARTICIPANT_REMOVED', payload);
+      io?.emit('participant_removed', payload);
+      const remainingAgents = Object.values(participants).some(
+        (p) => p.role === 'agent'
+      );
+      if (!remainingAgents && attrs.taskSid) {
+        try {
+          await updateTask(attrs.taskSid, {
+            assignmentStatus: 'wrapping',
+            reason: 'agent left'
+          });
+          pushEvent('CHAT_ORPHANED', {
+            conversationSid,
+            taskSid: attrs.taskSid
+          });
+          io?.emit('chat_orphaned', {
+            conversationSid,
+            taskSid: attrs.taskSid
+          });
+        } catch (err) {
+          console.error('task escalation error', err);
         }
       }
     } else if (eventType === 'onConversationStateUpdated') {


### PR DESCRIPTION
## Summary
- track conversation participants and agent join time in webhook route
- emit socket events for participant add/remove and mark orphaned chats
- update related TaskRouter tasks when agents join or depart

## Testing
- `npm test` *(fails: Missing script "test")*
- `(apps/server) npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a9109d3c64832a883f7f17f93b40bb