### PR TITLE
feat: prevalidate conversation creation

### DIFF
--- a/apps/server/src/conversations/service.js
+++ b/apps/server/src/conversations/service.js
@@ -170,6 +170,7 @@ export function configureServiceWebhooks({ preWebhookUrl } = {}) {
   if (preWebhookUrl) {
     payload.preWebhookUrl = preWebhookUrl;
     payload.preWebhookMethod = 'POST';
+    payload.preWebhookFilters = ['onMessageAdd', 'onConversationAdd'];
   }
   if (Object.keys(payload).length === 0) return Promise.resolve();
   return service.update(payload);

--- a/apps/server/src/routes/conversations-prewebhooks.route.js
+++ b/apps/server/src/routes/conversations-prewebhooks.route.js
@@ -1,4 +1,5 @@
 import express from 'express';
+import { fetchConversation } from '../conversations/service.js';
 
 const router = express.Router();
 
@@ -7,16 +8,53 @@ const router = express.Router();
 const MAX_MESSAGE_LENGTH = 1600;
 const bannedWords = ['banned', 'profanity'];
 
+// Allowed email domains for new conversations
+const allowedDomains = (process.env.ALLOWED_EMAIL_DOMAINS || '')
+  .split(',')
+  .map(s => s.trim().toLowerCase())
+  .filter(Boolean);
+
 function failsModeration(body = '') {
   const lower = body.toLowerCase();
   return bannedWords.some(w => lower.includes(w));
 }
 
-router.post('/', (req, res) => {
+router.post('/', async (req, res) => {
   const eventType = req.body.EventType || req.body.EventType?.toString();
-  console.log('[Conversations PreWebhook]', eventType, req.body?.MessageSid || '');
+  console.log('[Conversations PreWebhook]', eventType, req.body?.MessageSid || req.body?.ConversationSid || '');
 
   try {
+    if (eventType === 'onConversationAdd') {
+      let attrs = {};
+      try {
+        attrs = req.body.Attributes ? JSON.parse(req.body.Attributes) : {};
+      } catch (err) {
+        return res.status(422).send('Invalid attributes');
+      }
+
+      const email = attrs.email ? String(attrs.email).toLowerCase() : '';
+      if (!email) {
+        return res.status(422).send('email required');
+      }
+
+      const domain = email.split('@')[1];
+      if (allowedDomains.length && !allowedDomains.includes(domain)) {
+        return res.status(403).send('email domain not allowed');
+      }
+
+      // Ensure email/uniqueName is not already used
+      try {
+        await fetchConversation(email);
+        return res.status(409).send('conversation already exists');
+      } catch (err) {
+        if (err.status && err.status !== 404) {
+          console.error('[Conversations PreWebhook] uniqueness check failed', err);
+          return res.status(500).send('error');
+        }
+        // 404 => not found => ok
+      }
+    }
+
     if (eventType === 'onMessageAdd') {
       const body = req.body.Body || '';
 


### PR DESCRIPTION
## Summary
- validate onConversationAdd prewebhook requests
- add prewebhook filter for conversation creation

## Testing
- `node --test apps/server/test/auth.test.js`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68a913caa0d4832a87dde948e607f50b