### PR TITLE
feat: enable conversations post webhook

### DIFF
--- a/apps/server/src/conversations/service.js
+++ b/apps/server/src/conversations/service.js
@@ -189,16 +189,28 @@ export function updateConversationTimers(conversationSid, { inactive, closed } =
   return service.conversations(conversationSid).update(payload);
 }
 
-export function configureServiceWebhooks({ preWebhookUrl } = {}) {
+export function configureServiceWebhooks({
+  preWebhookUrl,
+  postWebhookUrl,
+  filters = [],
+  method = 'POST'
+} = {}) {
   if (!service) {
-    console.warn('[Conversations] Skipping service webhook configuration: TWILIO_CONVERSATIONS_SERVICE_SID is not set');
+    console.warn(
+      '[Conversations] Skipping service webhook configuration: TWILIO_CONVERSATIONS_SERVICE_SID is not set'
+    );
     return Promise.resolve();
   }
   const payload = {};
   if (preWebhookUrl) {
     payload.preWebhookUrl = preWebhookUrl;
-    payload.preWebhookMethod = 'POST';
-    payload.preWebhookFilters = ['onMessageAdd', 'onConversationAdd'];
+    payload.preWebhookMethod = method;
+    if (filters.length) payload.preWebhookFilters = filters;
+  }
+  if (postWebhookUrl) {
+    payload.postWebhookUrl = postWebhookUrl;
+    payload.postWebhookMethod = method;
+    if (filters.length) payload.postWebhookFilters = filters;
   }
   if (Object.keys(payload).length === 0) return Promise.resolve();
   return service.update(payload);

--- a/apps/server/src/index.js
+++ b/apps/server/src/index.js
@@ -68,8 +68,17 @@ app.use('/webhooks/conversations', conversationsWebhooksRoute);
 
 if (env.publicBaseUrl) {
   configureServiceWebhooks({
-    preWebhookUrl: `${env.publicBaseUrl}/webhooks/conversations/pre`
-  }).catch(e => console.error('Failed to configure Conversations pre-webhook', e));
+    preWebhookUrl: `${env.publicBaseUrl}/webhooks/conversations/pre`,
+    postWebhookUrl: `${env.publicBaseUrl}/webhooks/conversations`,
+    // Un solo "filters" sirve para pre y post; incluye eventos pre y post.
+    filters: [
+      'onConversationAdd', 'onMessageAdd',                    // PRE
+      'onMessageAdded', 'onMessageUpdated', 'onMessageRemoved',// POST
+      'onParticipantAdded', 'onParticipantRemoved',
+      'onDeliveryUpdated', 'onConversationStateUpdated'
+    ],
+    method: 'POST'
+  }).catch(e => console.error('Failed to configure Conversations webhooks', e));
 }
 // --- HTTP + Socket.IO con CORS ---
 const server = http.createServer(app);

--- a/apps/server/src/routes/conversations-prewebhooks.route.js
+++ b/apps/server/src/routes/conversations-prewebhooks.route.js
@@ -1,5 +1,6 @@
 import express from 'express';
 import { fetchConversation } from '../conversations/service.js';
+import { verifyTwilioSignature } from '../middleware/verifyTwilio.js';
 
 const router = express.Router();
 
@@ -19,7 +20,7 @@ function failsModeration(body = '') {
   return bannedWords.some(w => lower.includes(w));
 }
 
-router.post('/', async (req, res) => {
+router.post('/', verifyTwilioSignature, async (req, res) => {
   const eventType = req.body.EventType || req.body.EventType?.toString();
   console.log('[Conversations PreWebhook]', eventType, req.body?.MessageSid || req.body?.ConversationSid || '');
 

--- a/apps/server/src/routes/conversations-webhooks.route.js
+++ b/apps/server/src/routes/conversations-webhooks.route.js
@@ -8,12 +8,12 @@ import {
 } from '../services/taskrouter.js';
 import { fetchConversation, updateConversationAttributes } from '../conversations/service.js';
 import { logInteraction } from '../services/crm.js';
+import { verifyTwilioSignature } from '../middleware/verifyTwilio.js';
 
 const router = express.Router();
 
 // Twilio will POST events like onMessageAdded here if you attach a webhook per‑conversation.
-router.post('/', async (req, res) => {
-  // TODO: validate X-Twilio-Signature unless SKIP_TWILIO_VALIDATION=true (dev only)
+router.post('/', verifyTwilioSignature, async (req, res) => {
   const eventType = req.body.EventType || req.body.EventType?.toString();
   console.log('[Conversations Webhook]', eventType, req.body?.MessageSid || '');
   const io = req.app.get('io');


### PR DESCRIPTION
## Summary
- configure Conversations service with pre/post webhooks and filters
- verify Twilio signatures on conversation webhooks

## Testing
- `npm test --workspaces` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a91dc04c70832a86e672fa981bc0d7