### PR TITLE
Add crypto import for WebChat token route

### DIFF
--- a/apps/server/src/routes/chat-token.route.js
+++ b/apps/server/src/routes/chat-token.route.js
@@ -1,4 +1,5 @@
 import express from 'express';
+import crypto from 'crypto';
 import { createConversationsToken } from '../conversations/tokens.js';
 
 


### PR DESCRIPTION
## Summary
- import Node's crypto module in chat token route to support random guest identities

## Testing
- `npm test` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_68a91dd65604832a8bd68ed270a79e43